### PR TITLE
routing_rules: Fix schema

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,11 +4,16 @@ page_title: "p0 Provider"
 subcategory: ""
 description: |-
   Configures a P0 organization. Requires a P0 account. Go to https://p0.app to create an account.
+  You must also configure a P0 API token (on your P0 app "/settings" page). Then run Terraform with your API token in
+  the P0APITOKEN environment variable.
 ---
 
 # p0 Provider
 
 Configures a P0 organization. Requires a P0 account. Go to https://p0.app to create an account.
+
+You must also configure a P0 API token (on your P0 app "/settings" page). Then run Terraform with your API token in
+the P0_API_TOKEN environment variable.
 
 ## Example Usage
 

--- a/docs/resources/routing_rules.md
+++ b/docs/resources/routing_rules.md
@@ -17,13 +17,13 @@ See [the P0 request-routing docs](https://docs.p0.dev/just-in-time-access/reques
 ```terraform
 resource "p0_routing_rules" "example" {
   rule {
-    requestor {
+    requestor = {
       type      = "group"
       directory = "okta"
       id        = "00abcdefghijklmno697"
       label     = "AWS Developers"
     }
-    resource {
+    resource = {
       type    = "integration"
       service = "aws"
       filters = {
@@ -56,45 +56,16 @@ resource "p0_routing_rules" "example" {
 <a id="nestedblock--rule"></a>
 ### Nested Schema for `rule`
 
+Required:
+
+- `requestor` (Attributes) Controls who has access. See [the Requestor docs](https://docs.p0.dev/just-in-time-access/request-routing#requestor). (see [below for nested schema](#nestedatt--rule--requestor))
+- `resource` (Attributes) Controls what is accessed. See [the Resource docs](https://docs.p0.dev/just-in-time-access/request-routing#resource). (see [below for nested schema](#nestedatt--rule--resource))
+
 Optional:
 
 - `approval` (Block List) Determines access requirements. See [the Approval docs](https://docs.p0.dev/just-in-time-access/request-routing#approval). (see [below for nested schema](#nestedblock--rule--approval))
-- `requestor` (Block, Optional) Controls who has access. See [the Requestor docs](https://docs.p0.dev/just-in-time-access/request-routing#requestor). (see [below for nested schema](#nestedblock--rule--requestor))
-- `resource` (Block, Optional) Controls what is accessed. See [the Resource docs](https://docs.p0.dev/just-in-time-access/request-routing#resource). (see [below for nested schema](#nestedblock--rule--resource))
 
-<a id="nestedblock--rule--approval"></a>
-### Nested Schema for `rule.approval`
-
-Required:
-
-- `type` (String) Determines trust requirements for access. If empty, access is disallowed. Except for 'deny', meeting any requirement is sufficient to grant access. Possible values:
-    - 'auto': Access is granted according to the requirements of the specified 'integration'
-    - 'deny': Access is always denied
-    - 'escalation': Access may be approved by on-call members of the specified services, who are paged when access is requested
-    - 'group': Access may be granted by any member of the defined directory group
-    - 'p0': Access may be granted by any user with the P0 approval role (defined in the P0 app)
-
-Optional:
-
-- `directory` (String) May only be used if 'type' is 'group'. One of "azure-ad", "okta", or "workspace".
-- `id` (String) May only be used if 'type' is 'group'. This is the directory's internal group identifier for matching approvers.
-- `integration` (String) May only be used if 'type' is 'auto' or 'escalation'. Possible values:
-    - 'pagerduty': Access is granted if the requestor is on-call.
-- `label` (String) May only be used if 'type' is 'group'. This is any human-readable name for the directory group specified in the 'id' attribute.
-- `options` (Attributes) If present, determines additional trust requirements. (see [below for nested schema](#nestedatt--rule--approval--options))
-- `services` (List of String) May only be used if 'type' is 'escalation'. Defines which services to page on escalation.
-
-<a id="nestedatt--rule--approval--options"></a>
-### Nested Schema for `rule.approval.options`
-
-Optional:
-
-- `allow_one_party` (Boolean) If true, allows requestors to approve their own requests.
-- `require_reason` (Boolean) If true, requires access requests to include a reason.
-
-
-
-<a id="nestedblock--rule--requestor"></a>
+<a id="nestedatt--rule--requestor"></a>
 ### Nested Schema for `rule.requestor`
 
 Required:
@@ -112,7 +83,7 @@ Optional:
 - `uid` (String) May only be used if 'type' is 'user'. This is the user's email address.
 
 
-<a id="nestedblock--rule--resource"></a>
+<a id="nestedatt--rule--resource"></a>
 ### Nested Schema for `rule.resource`
 
 Required:
@@ -143,3 +114,35 @@ Optional:
 - `key` (String) The value being filtered. Required if the filter effect is 'keep' or 'remove'.
 See [docs](https://docs.p0.dev/just-in-time-access/request-routing#resource) for available values.
 - `pattern` (String) Filter patterns. Patterns are unanchored.
+
+
+
+<a id="nestedblock--rule--approval"></a>
+### Nested Schema for `rule.approval`
+
+Required:
+
+- `type` (String) Determines trust requirements for access. If empty, access is disallowed. Except for 'deny', meeting any requirement is sufficient to grant access. Possible values:
+    - 'auto': Access is granted according to the requirements of the specified 'integration'
+    - 'deny': Access is always denied
+    - 'escalation': Access may be approved by on-call members of the specified services, who are paged when access is requested
+    - 'group': Access may be granted by any member of the defined directory group
+    - 'p0': Access may be granted by any user with the P0 approval role (defined in the P0 app)
+
+Optional:
+
+- `directory` (String) May only be used if 'type' is 'group'. One of "azure-ad", "okta", or "workspace".
+- `id` (String) May only be used if 'type' is 'group'. This is the directory's internal group identifier for matching approvers.
+- `integration` (String) May only be used if 'type' is 'auto' or 'escalation'. Possible values:
+    - 'pagerduty': Access is granted if the requestor is on-call.
+- `label` (String) May only be used if 'type' is 'group'. This is any human-readable name for the directory group specified in the 'id' attribute.
+- `options` (Attributes) If present, determines additional trust requirements. (see [below for nested schema](#nestedatt--rule--approval--options))
+- `services` (List of String) May only be used if 'type' is 'escalation'. Defines which services to page on escalation.
+
+<a id="nestedatt--rule--approval--options"></a>
+### Nested Schema for `rule.approval.options`
+
+Optional:
+
+- `allow_one_party` (Boolean) If true, allows requestors to approve their own requests.
+- `require_reason` (Boolean) If true, requires access requests to include a reason.

--- a/examples/resources/p0_routing_rules/resource.tf
+++ b/examples/resources/p0_routing_rules/resource.tf
@@ -1,12 +1,12 @@
 resource "p0_routing_rules" "example" {
   rule {
-    requestor {
+    requestor = {
       type      = "group"
       directory = "okta"
       id        = "00abcdefghijklmno697"
       label     = "AWS Developers"
     }
-    resource {
+    resource = {
       type    = "integration"
       service = "aws"
       filters = {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -44,7 +44,10 @@ func (p *P0Provider) Metadata(ctx context.Context, req provider.MetadataRequest,
 
 func (p *P0Provider) Schema(ctx context.Context, req provider.SchemaRequest, resp *provider.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Configures a P0 organization. Requires a P0 account. Go to https://p0.app to create an account.",
+		MarkdownDescription: `Configures a P0 organization. Requires a P0 account. Go to https://p0.app to create an account.
+
+You must also configure a P0 API token (on your P0 app "/settings" page). Then run Terraform with your API token in
+the P0_API_TOKEN environment variable.`,
 		Attributes: map[string]schema.Attribute{
 			"org": schema.StringAttribute{
 				MarkdownDescription: "Your P0 organization identifier.",

--- a/internal/provider/resources/routing_rules.go
+++ b/internal/provider/resources/routing_rules.go
@@ -111,8 +111,9 @@ See [the P0 request-routing docs](https://docs.p0.dev/just-in-time-access/reques
 			"rule": schema.SetNestedBlock{
 				MarkdownDescription: "All access rules",
 				NestedObject: schema.NestedBlockObject{
-					Blocks: map[string]schema.Block{
-						"requestor": schema.SingleNestedBlock{
+					Attributes: map[string]schema.Attribute{
+						"requestor": schema.SingleNestedAttribute{
+							Required:            true,
 							MarkdownDescription: `Controls who has access. See [the Requestor docs](https://docs.p0.dev/just-in-time-access/request-routing#requestor).`,
 							Attributes: map[string]schema.Attribute{
 								"directory": schema.StringAttribute{
@@ -134,7 +135,8 @@ See [the P0 request-routing docs](https://docs.p0.dev/just-in-time-access/reques
 								"uid": schema.StringAttribute{MarkdownDescription: `May only be used if 'type' is 'user'. This is the user's email address.`, Optional: true},
 							},
 						},
-						"resource": schema.SingleNestedBlock{
+						"resource": schema.SingleNestedAttribute{
+							Required:            true,
 							MarkdownDescription: `Controls what is accessed. See [the Resource docs](https://docs.p0.dev/just-in-time-access/request-routing#resource).`,
 							Attributes: map[string]schema.Attribute{
 								"filters": schema.MapNestedAttribute{
@@ -176,6 +178,8 @@ See [the Resource docs](https://docs.p0.dev/just-in-time-access/request-routing#
 								},
 							},
 						},
+					},
+					Blocks: map[string]schema.Block{
 						"approval": schema.ListNestedBlock{
 							MarkdownDescription: `Determines access requirements. See [the Approval docs](https://docs.p0.dev/just-in-time-access/request-routing#approval).`,
 							NestedObject: schema.NestedBlockObject{


### PR DESCRIPTION
Resources and requestors are required, so should be attributes, not blocks (which are always optional).

Also improve documentation around setting the P0_API_TOKEN environment variable.