### PR TITLE
Fix custom_role naming for GCP staged resources

### DIFF
--- a/internal/provider/resources/install/gcp/common.go
+++ b/internal/provider/resources/install/gcp/common.go
@@ -20,7 +20,7 @@ type gcpRoleMetadata struct {
 
 type gcpPermissionsMetadata struct {
 	Permissions []string        `json:"requiredPermissions" tfsdk:"permissions"`
-	Role        gcpRoleMetadata `json:"customRole" tfsdk:"custom_role"`
+	CustomRole  gcpRoleMetadata `json:"customRole" tfsdk:"custom_role"`
 }
 
 type gcpPermissionsMetadataWithPredefinedRole struct {

--- a/internal/provider/resources/install/gcp/iam_assessment_staged.go
+++ b/internal/provider/resources/install/gcp/iam_assessment_staged.go
@@ -39,7 +39,7 @@ type gcpIamAssessmentStagedApi struct {
 	Item struct {
 		State string `json:"state"`
 	} `json:"item"`
-	Metadata gcpPermissionsMetadataWithPredefinedRole `json:"metadata"`
+	Metadata gcpPermissionsMetadata `json:"metadata"`
 }
 
 func (r *GcpIamAssessmentStaged) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {


### PR DESCRIPTION
The Terraform attribute name for custom roles is custom_role, not role.

This commit fixes the naming and data structure to correct this misassignment for iam_assessment_staged resources.