### PR TITLE
provider: Add "host" attribute

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -29,3 +29,7 @@ provider "p0" {
 ### Required
 
 - `org` (String) Your P0 organization identifier.
+
+### Optional
+
+- `host` (String) Your P0 application API host (defaults to `https://api.p0.app`)

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ provider "p0" {
 
 ### Required
 
-- `org` (String) Your P0 organization identifier.
+- `org` (String) Your P0 organization identifier
 
 ### Optional
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -58,7 +58,7 @@ the P0_API_TOKEN environment variable.`,
 				Optional:            true,
 			},
 			"org": schema.StringAttribute{
-				MarkdownDescription: "Your P0 organization identifier.",
+				MarkdownDescription: "Your P0 organization identifier",
 				Required:            true,
 			},
 		},

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -37,7 +37,8 @@ type P0Provider struct {
 
 // P0ProviderModel describes the provider data model.
 type P0ProviderModel struct {
-	Org types.String `tfsdk:"org"`
+	Host types.String `tfsdk:"host"`
+	Org  types.String `tfsdk:"org"`
 }
 
 func (p *P0Provider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
@@ -52,6 +53,10 @@ func (p *P0Provider) Schema(ctx context.Context, req provider.SchemaRequest, res
 You must also configure a P0 API token (on your P0 app "/settings" page). Then run Terraform with your API token in
 the P0_API_TOKEN environment variable.`,
 		Attributes: map[string]schema.Attribute{
+			"host": schema.StringAttribute{
+				MarkdownDescription: "Your P0 application API host (defaults to `https://api.p0.app`)",
+				Optional:            true,
+			},
 			"org": schema.StringAttribute{
 				MarkdownDescription: "Your P0 organization identifier.",
 				Required:            true,
@@ -83,8 +88,7 @@ func (p *P0Provider) Configure(ctx context.Context, req provider.ConfigureReques
 		)
 	}
 
-	// For dev only: optionally override P0 app server
-	p0_host := os.Getenv("P0_HOST")
+	p0_host := model.Host.ValueString()
 	if p0_host == "" {
 		p0_host = "https://api.p0.app"
 	}


### PR DESCRIPTION
Allows the user to specify a P0 host other than the standard api.p0.app.