### PR TITLE
gcp: Update for direct access-logging

### DIFF
--- a/docs/resources/gcp.md
+++ b/docs/resources/gcp.md
@@ -37,26 +37,17 @@ resource "p0_gcp" "example" {
 
 Read-Only:
 
-- `logging` (Attributes) Describes expected Cloud Logging infrastructure (see [below for nested schema](#nestedatt--access_logs--logging))
-- `predefined_role` (String) The predefined role that should be granted to P0, in order to install projects for IAM management
-- `pub_sub` (Attributes) Describes expected Pub/Sub infrastructure (see [below for nested schema](#nestedatt--access_logs--pub_sub))
+- `custom_role` (Attributes) Describes the custom role that should be created and assigned to P0's service account (see [below for nested schema](#nestedatt--access_logs--custom_role))
+- `permissions` (List of String) Permissions that should be granted to P0 via the custom role, described in the 'role' attribute,
+in order to install projects for access logging
 
-<a id="nestedatt--access_logs--logging"></a>
-### Nested Schema for `access_logs.logging`
-
-Read-Only:
-
-- `filter` (String) Logs should be directed to a logging sink with this filter
-- `role` (String) The project's logging service account should have this predefined role
-- `sink_id` (String) Logs should be directed to a logging sink with this ID
-
-
-<a id="nestedatt--access_logs--pub_sub"></a>
-### Nested Schema for `access_logs.pub_sub`
+<a id="nestedatt--access_logs--custom_role"></a>
+### Nested Schema for `access_logs.custom_role`
 
 Read-Only:
 
-- `topic_id` (String) Logs should be directed to a Pub/Sub topic with this ID
+- `id` (String) The custom role expected identifier
+- `name` (String) The custom role's expected title
 
 
 

--- a/docs/resources/gcp_organization_access_logs.md
+++ b/docs/resources/gcp_organization_access_logs.md
@@ -7,7 +7,7 @@ description: |-
   which enhances IAM assessment. Note that P0 will have access to logs from all your projects, not just those
   configured for IAM assessment.
   To use this resource, you must also:
-  create a Pub/Sub topic,create an organization logging sink, publishing to this topic,grant your logging service account permissions to publish to this Pub/Sub topic, andgrant P0 the ability to subscribe to this Pub/Sub topic.
+  grant P0 the ability to create logging sinks on your organization.
   Use the read-only attributes defined on p0_gcp to create the requisite Google Cloud infrastructure.
   P0 recommends defining this infrastructure according to the example usage pattern.
 ---
@@ -19,10 +19,7 @@ which enhances IAM assessment. Note that P0 will have access to logs from all yo
 configured for IAM assessment.
 
 To use this resource, you must also:
-- create a Pub/Sub topic,
-- create an organization logging sink, publishing to this topic,
-- grant your logging service account permissions to publish to this Pub/Sub topic, and
-- grant P0 the ability to subscribe to this Pub/Sub topic.
+- grant P0 the ability to create logging sinks on your organization.
 
 Use the read-only attributes defined on `p0_gcp` to create the requisite Google Cloud infrastructure.
 
@@ -33,10 +30,6 @@ P0 recommends defining this infrastructure according to the example usage patter
 ```terraform
 resource "p0_gcp" "example" {
   organization_id = "123456789012"
-}
-
-locals {
-  logs_topic_project = "my-logs-project"
 }
 
 resource "google_organization_iam_audit_config" "example" {
@@ -53,44 +46,26 @@ resource "google_organization_iam_audit_config" "example" {
   }
 }
 
-# Data access logs are sent to P0 using this Pub/Sub topic
-resource "google_pubsub_topic" "example" {
-  project = locals.logs_topic_project
-  name    = p0_gcp.example.access_logs.pub_sub.topic_id
-}
-
-# The log sink that writes to the P0 access-logging Pub/Sub topic
-resource "google_logging_organization_sink" "example" {
-  org_id      = p0_gcp.example.org_id
-  name        = p0_gcp.example.access_logs.logging.sink_id
-  destination = "pubsub.googleapis.com/projects/${locals.logs_topic_project}/topics/${google_pubsub_topic.example.name}"
-  description = "P0 data access log sink"
-
-  filter = p0_gcp.example.access_logs.logging.filter
+resource "google_organization_iam_custom_role" "example" {
+  org_id      = p0_gcp.example.organization_id
+  role_id     = p0_gcp.example.access_logs.custom_role.id
+  title       = p0_gcp.example.access_logs.custom_role.name
+  permissions = p0_gcp.example.access_logs.permissions
 }
 
 # Grants the logging service account permission to write to the access-logging Pub/Sub topic
-resource "google_pubsub_topic_iam_member" "logging_example" {
-  project = locals.logs_topic_project
-  role    = p0_gcp.example.access_logs.logging.role
-  topic   = google_pubsub_topic.example.name
-  member  = google_logging_organization_sink.example.writer_identity
-}
-
-# Grants P0 permission to read from the access-logging Pub/Sub topic
-resource "google_pubsub_topic_iam_member" "p0_example" {
-  project = locals.logs_topic_project
-  role    = p0_gcp.example.access_logs.predefined_role
-  topic   = google_pubsub_topic.example.name
-  member  = "serviceAccount:${p0_gcp.example.serviceAccountEmail}"
+resource "google_organization_iam_member" "example" {
+  org_id = p0_gcp.example.organization_id
+  role   = google_organization_iam_custom_role.example.name
+  member = "serviceAccount:${p0_gcp.example.service_account_email}"
 }
 
 # Install organization access logging in P0
 resource "p0_gcp_access_logs" "example" {
   topic_project_id = locals.logs_topic_project
   depends_on = [
-    google_logging_project_sink.example,
-    google_pubsub_topic_iam_member.p0_example
+    google_organization_iam_audit_config.example,
+    google_organization_iam_member.example
   ]
 }
 ```

--- a/examples/resources/p0_gcp_access_logs/resource.tf
+++ b/examples/resources/p0_gcp_access_logs/resource.tf
@@ -28,43 +28,25 @@ resource "google_project_iam_audit_config" "example" {
   }
 }
 
-# Data access logs are sent to P0 using this Pub/Sub topic
-resource "google_pubsub_topic" "example" {
-  project = locals.project
-  name    = p0_gcp.example.access_logs.pub_sub.topic_id
-}
-
-# The log sink that writes to the P0 access-logging Pub/Sub topic
-resource "google_logging_project_sink" "example" {
+resource "google_project_iam_custom_role" "example" {
   project     = locals.project
-  name        = p0_gcp.example.access_logs.logging.sink_id
-  destination = "pubsub.googleapis.com/projects/my_project/topics/${google_pubsub_topic.example.name}"
-  description = "P0 data access log sink"
-
-  filter = p0_gcp.example.access_logs.logging.filter
+  role_id     = p0_gcp.example.access_logs.custom_role.id
+  title       = p0_gcp.example.access_logs.custom_role.name
+  permissions = p0_gcp.example.access_logs.permissions
 }
 
 # Grants the logging service account permission to write to the access-logging Pub/Sub topic
-resource "google_pubsub_topic_iam_member" "logging_example" {
+resource "google_project_iam_member" "example" {
   project = locals.project
-  role    = p0_gcp.example.access_logs.logging.role
-  topic   = google_pubsub_topic.example.name
-  member  = google_logging_project_sink.example.writer_identity
-}
-
-# Grants P0 permission to read from the access-logging Pub/Sub topic
-resource "google_pubsub_topic_iam_member" "p0_example" {
-  project = locals.project
-  role    = p0_gcp.example.access_logs.predefined_role
-  topic   = google_pubsub_topic.example.name
-  member  = "serviceAccount:${p0_gcp.example.serviceAccountEmail}"
+  role    = google_project_iam_custom_role.example.name
+  member  = "serviceAccount:${p0_gcp.example.service_account_email}"
 }
 
 # Finish the P0 access-logs installation
 resource "p0_gcp_access_logs" "example" {
   project = locals.project
   depends_on = [
-    google_logging_project_sink.example,
-    google_pubsub_topic_iam_member.p0_example
+    google_project_iam_audit_config.example,
+    google_project_iam_member.example
   ]
 }

--- a/examples/resources/p0_gcp_organization_access_logs/resource.tf
+++ b/examples/resources/p0_gcp_organization_access_logs/resource.tf
@@ -2,10 +2,6 @@ resource "p0_gcp" "example" {
   organization_id = "123456789012"
 }
 
-locals {
-  logs_topic_project = "my-logs-project"
-}
-
 resource "google_organization_iam_audit_config" "example" {
   org_id  = p0_gcp.example.org_id
   service = "allServices"
@@ -20,43 +16,25 @@ resource "google_organization_iam_audit_config" "example" {
   }
 }
 
-# Data access logs are sent to P0 using this Pub/Sub topic
-resource "google_pubsub_topic" "example" {
-  project = locals.logs_topic_project
-  name    = p0_gcp.example.access_logs.pub_sub.topic_id
-}
-
-# The log sink that writes to the P0 access-logging Pub/Sub topic
-resource "google_logging_organization_sink" "example" {
-  org_id      = p0_gcp.example.org_id
-  name        = p0_gcp.example.access_logs.logging.sink_id
-  destination = "pubsub.googleapis.com/projects/${locals.logs_topic_project}/topics/${google_pubsub_topic.example.name}"
-  description = "P0 data access log sink"
-
-  filter = p0_gcp.example.access_logs.logging.filter
+resource "google_organization_iam_custom_role" "example" {
+  org_id      = p0_gcp.example.organization_id
+  role_id     = p0_gcp.example.access_logs.custom_role.id
+  title       = p0_gcp.example.access_logs.custom_role.name
+  permissions = p0_gcp.example.access_logs.permissions
 }
 
 # Grants the logging service account permission to write to the access-logging Pub/Sub topic
-resource "google_pubsub_topic_iam_member" "logging_example" {
-  project = locals.logs_topic_project
-  role    = p0_gcp.example.access_logs.logging.role
-  topic   = google_pubsub_topic.example.name
-  member  = google_logging_organization_sink.example.writer_identity
-}
-
-# Grants P0 permission to read from the access-logging Pub/Sub topic
-resource "google_pubsub_topic_iam_member" "p0_example" {
-  project = locals.logs_topic_project
-  role    = p0_gcp.example.access_logs.predefined_role
-  topic   = google_pubsub_topic.example.name
-  member  = "serviceAccount:${p0_gcp.example.serviceAccountEmail}"
+resource "google_organization_iam_member" "example" {
+  org_id = p0_gcp.example.organization_id
+  role   = google_organization_iam_custom_role.example.name
+  member = "serviceAccount:${p0_gcp.example.service_account_email}"
 }
 
 # Install organization access logging in P0
 resource "p0_gcp_access_logs" "example" {
   topic_project_id = locals.logs_topic_project
   depends_on = [
-    google_logging_project_sink.example,
-    google_pubsub_topic_iam_member.p0_example
+    google_organization_iam_audit_config.example,
+    google_organization_iam_member.example
   ]
 }

--- a/internal/provider/resources/install/gcp/access_logs.go
+++ b/internal/provider/resources/install/gcp/access_logs.go
@@ -33,11 +33,8 @@ func (r *GcpAccessLogs) Schema(ctx context.Context, req resource.SchemaRequest, 
 which enhances IAM assessment.
 
 To use this resource, you must also:
-- install the ` + "`p0_gcp_iam_assessment`" + ` resource,
-- create a Pub/Sub topic,
-- create a logging sink, publishing to this topic,
-- grant your logging service account permissions to publish to this Pub/Sub topic, and
-- grant P0 the ability to subscribe to this Pub/Sub topic.
+- install the ` + "`p0_gcp_iam_assessment`" + ` resource, and
+- grant P0 the ability to create logging sinks in your project.
 
 Use the read-only attributes defined on ` + "`p0_gcp`" + ` to create the requisite Google Cloud infrastructure.
 

--- a/internal/provider/resources/install/gcp/org_access_logs.go
+++ b/internal/provider/resources/install/gcp/org_access_logs.go
@@ -50,10 +50,7 @@ which enhances IAM assessment. Note that P0 will have access to logs from all yo
 configured for IAM assessment.
 
 To use this resource, you must also:
-- create a Pub/Sub topic,
-- create an organization logging sink, publishing to this topic,
-- grant your logging service account permissions to publish to this Pub/Sub topic, and
-- grant P0 the ability to subscribe to this Pub/Sub topic.
+- grant P0 the ability to create logging sinks on your organization.
 
 Use the read-only attributes defined on ` + "`p0_gcp`" + ` to create the requisite Google Cloud infrastructure.
 


### PR DESCRIPTION
On 2024 July 30, P0 updated GCP access-logging ingest to transition from a Pub/Sub-based ingest architecture, to a direct write from the organization's logging sink.

Update the P0 TF provider to match this new model.