### PR TITLE
Add support for isSudoEnabled to AWS SSH installations

### DIFF
--- a/docs/resources/ssh_aws.md
+++ b/docs/resources/ssh_aws.md
@@ -32,6 +32,7 @@ resource "p0_ssh_aws" "example" {
 ### Optional
 
 - `group_key` (String) If present, AWS instances will be grouped by the value of this tag. Access can be requested, in one request, to all instances with a shared tag value
+- `is_sudo_enabled` (Boolean) If true, users will be able to request sudo access to the instances
 - `label` (String) The AWS account's alias (if available)
 
 ### Read-Only


### PR DESCRIPTION
Adds a new management property, `is_sudo_enabled`, to the AWS SSH installation resource. The parameter defaults to "false" and can be omitted. 

### Examples

##### Disabled
```
resource "p0_ssh_aws" "aws-example" {
  account_id = "123456789012"
  group_key  = "Customer"
}
```

```
resource "p0_ssh_aws" "aws-example" {
  account_id = "123456789012"
  group_key  = "Customer"
  is_sudo_enabled = false
}
```

##### Enabled
```
resource "p0_ssh_aws" "aws-example" {
  account_id = "123456789012"
  group_key  = "Customer"
  is_sudo_enabled = true
}
```