### PR TITLE
Enhance SSH installation resources

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,8 +47,11 @@ terraform plan
 ```
 
 If you are using a local build of the P0 API server, you can also set that in your
-environment:
+`main.tf`:
 
-```bash
-export P0_HOST=...
+```
+provider "p0" {
+  org = "p0-nathan"
+  host = "http://localhost:8088/"
+}
 ```

--- a/docs/resources/ssh_gcp.md
+++ b/docs/resources/ssh_gcp.md
@@ -28,6 +28,11 @@ resource "p0_ssh_gcp" "example" {
 
 - `project_id` (String) The Google Cloud project ID
 
+### Optional
+
+- `group_key` (String) If present, Google Cloud instances will be grouped by the value of this tag. Access can be requested, in one request, to all instances with a shared tag value
+- `is_sudo_enabled` (Boolean) If true, users will be able to request sudo access to the instances
+
 ### Read-Only
 
 - `label` (String) The Google Cloud project's alias (if available)

--- a/internal/provider/resources/install/ssh/aws.go
+++ b/internal/provider/resources/install/ssh/aws.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/p0-security/terraform-provider-p0/internal"
@@ -74,6 +75,8 @@ Installing SSH allows you to manage access to your servers on AWS.`,
 			"group_key": schema.StringAttribute{
 				MarkdownDescription: `If present, AWS instances will be grouped by the value of this tag. Access can be requested, in one request, to all instances with a shared tag value`,
 				Optional:            true,
+				Computed:            true,
+				Default:             stringdefault.StaticString(""),
 			},
 			"is_sudo_enabled": schema.BoolAttribute{
 				MarkdownDescription: `If true, users will be able to request sudo access to the instances`,


### PR DESCRIPTION
### Changes
- Adds two new properties, `group_key` and `is_sudo_enabled`, to the Google Cloud SSH installation resource. 
- Makes AWS Group Key optional and provides a default value of ""
- Updates the contribution guide to use the host parameter in `main.tf` instead of the environment variable.
- Sorts some Google Cloud SSH parameters in alphabetical order.

### Examples

##### Full configuration
```
resource "p0_ssh_gcp" "gcp-example" {
  project_id      = "p0-gcp-project"
  group_key       = "p0-gcp-project/developer"
  is_sudo_enabled = true
}
```

##### Minimum required parameters
```
resource "p0_ssh_gcp" "gcp-example" {
  project_id      = "p0-gcp-project"
}

```