### PR TITLE
Fix: Add plan modifiers for ssh install resources

### DIFF
--- a/internal/provider/resources/install/ssh/aws.go
+++ b/internal/provider/resources/install/ssh/aws.go
@@ -11,7 +11,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/p0-security/terraform-provider-p0/internal"
@@ -70,6 +72,9 @@ Installing SSH allows you to manage access to your servers on AWS.`,
 				Required:            true,
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(installaws.AwsAccountIdRegex, "AWS account IDs should be numeric"),
+				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
 				},
 			},
 			"group_key": schema.StringAttribute{

--- a/internal/provider/resources/install/ssh/gcp.go
+++ b/internal/provider/resources/install/ssh/gcp.go
@@ -10,7 +10,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/p0-security/terraform-provider-p0/internal"
 	installresources "github.com/p0-security/terraform-provider-p0/internal/provider/resources/install"
@@ -81,6 +83,9 @@ Installing SSH allows you to manage access to your servers on Google Cloud.`,
 			"project_id": schema.StringAttribute{
 				MarkdownDescription: "The Google Cloud project ID",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"state": schema.StringAttribute{
 				Computed:            true,


### PR DESCRIPTION
Add plan modifiers for ssh installations for AWS and GCP. These make sure that a new plan gets generated when important parameters like account id or project id change.