### PR TITLE
Add optional index field to terraform provider for Splunk HEC

### DIFF
--- a/docs/resources/splunk_audit_logs.md
+++ b/docs/resources/splunk_audit_logs.md
@@ -29,6 +29,10 @@ resource "p0_splunk_audit_logs" "example" {
 - `hec_token_cleartext` (String, Sensitive) The cleartext token of the HTTP event collector
 - `token_id` (String) A user-specified token ID of the HTTP event collector
 
+### Optional
+
+- `index` (String) The index of the HTTP event collector to use
+
 ### Read-Only
 
 - `hec_token_hash` (String) The hash of the token of the HTTP event collector


### PR DESCRIPTION
Adds an optional "index" field for the Splunk HEC.

From testing locally, this appears to work with https://github.com/p0-security/app/pull/2879