### PR TITLE
ENG-3759: Support create of routing rules

### DIFF
--- a/docs/resources/gcp_security_perimeter.md
+++ b/docs/resources/gcp_security_perimeter.md
@@ -89,6 +89,23 @@ resource "google_cloud_run_service_iam_member" "invoker_access" {
   member   = "serviceAccount:customer-p0-gcp-sa@p0-gcp-project.iam.gserviceaccount.com"
 }
 
+# Create the p0 security perimeter invoker role, this is assumed by p0 service account
+resource "google_project_iam_custom_role" "p0_security_perimeter_invoker_role" {
+  role_id     = p0_gcp_security_perimeter_staged.p0-dev-account.custom_role.id
+  title       = p0_gcp_security_perimeter_staged.p0-dev-account.custom_role.name
+  description = "P0 IAM cloud run invoker role"
+  project     = var.project_id
+  permissions = p0_gcp_security_perimeter_staged.p0-dev-account.required_permissions
+}
+
+# Grants the p0 service account access to the role just created
+resource "google_cloud_run_service_iam_member" "invoker_access" {
+  service  = google_cloud_run_service.p0_security_perimeter.name
+  location = google_cloud_run_service.p0_security_perimeter.location
+  role     = "projects/p0-gcp-project/roles/p0SecurityPerimeterInvoker"
+  member   = "serviceAccount:customer-p0-gcp-sa@p0-gcp-project.iam.gserviceaccount.com"
+}
+
 resource "p0_gcp_security_perimeter" "p0-dev-account" {
   project         = var.project_id
   allowed_domains = p0_gcp_security_perimeter_staged.p0-dev-account.allowed_domains

--- a/docs/resources/gcp_security_perimeter_staged.md
+++ b/docs/resources/gcp_security_perimeter_staged.md
@@ -33,6 +33,7 @@ To use this resource, you must also:
 - `allowed_domains` (String) The list of domains that are allowed to access the Cloud Run service.
 - `custom_role` (Attributes) Describes the custom role that should be created and assigned to P0's service account (see [below for nested schema](#nestedatt--custom_role))
 - `image_digest` (String) The hash value of the image that is deployed to the Cloud Run service.
+- `project_reader_role` (Attributes) Describes the project reader role that should be created and assigned to P0's service account (see [below for nested schema](#nestedatt--project_reader_role))
 - `required_permissions` (List of String) A list of permissions required by the security perimeter invoker role.
 - `state` (String) This item's install progress in the P0 application:
 	- 'stage': The item has been staged for installation
@@ -41,6 +42,23 @@ To use this resource, you must also:
 
 <a id="nestedatt--custom_role"></a>
 ### Nested Schema for `custom_role`
+
+Read-Only:
+
+- `id` (String) The custom role expected identifier
+- `name` (String) The custom role's expected title
+
+
+<a id="nestedatt--project_reader_role"></a>
+### Nested Schema for `project_reader_role`
+
+Read-Only:
+
+- `custom_role` (Attributes) Describes the custom role that should be created and assigned to P0's service account (see [below for nested schema](#nestedatt--project_reader_role--custom_role))
+- `required_permissions` (List of String) Described the permissions that the project reader role should contain.
+
+<a id="nestedatt--project_reader_role--custom_role"></a>
+### Nested Schema for `project_reader_role.custom_role`
 
 Read-Only:
 

--- a/examples/resources/p0_gcp_security_perimeter/resource.tf
+++ b/examples/resources/p0_gcp_security_perimeter/resource.tf
@@ -65,6 +65,23 @@ resource "google_cloud_run_service_iam_member" "invoker_access" {
   member   = "serviceAccount:customer-p0-gcp-sa@p0-gcp-project.iam.gserviceaccount.com"
 }
 
+# Create the p0 security perimeter invoker role, this is assumed by p0 service account
+resource "google_project_iam_custom_role" "p0_security_perimeter_invoker_role" {
+  role_id     = p0_gcp_security_perimeter_staged.p0-dev-account.custom_role.id
+  title       = p0_gcp_security_perimeter_staged.p0-dev-account.custom_role.name
+  description = "P0 IAM cloud run invoker role"
+  project     = var.project_id
+  permissions = p0_gcp_security_perimeter_staged.p0-dev-account.required_permissions
+}
+
+# Grants the p0 service account access to the role just created
+resource "google_cloud_run_service_iam_member" "invoker_access" {
+  service  = google_cloud_run_service.p0_security_perimeter.name
+  location = google_cloud_run_service.p0_security_perimeter.location
+  role     = "projects/p0-gcp-project/roles/p0SecurityPerimeterInvoker"
+  member   = "serviceAccount:customer-p0-gcp-sa@p0-gcp-project.iam.gserviceaccount.com"
+}
+
 resource "p0_gcp_security_perimeter" "p0-dev-account" {
   project         = var.project_id
   allowed_domains = p0_gcp_security_perimeter_staged.p0-dev-account.allowed_domains


### PR DESCRIPTION
Currently, creating routing rules (when Terraform has no existing state) 
fails. Fixed the logic to create the routing rules by:
    
* Removing state load (it's null anyway)
* Retrieving the version from the workflow object
* Adding the version to the payload
* Posting the set of routing rules defined in Terraform