### PR TITLE
ENG-3878 Move the license rule resource to its own module

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -18,12 +18,12 @@ import (
 
 	"github.com/p0-security/terraform-provider-p0/internal"
 	installsplunk "github.com/p0-security/terraform-provider-p0/internal/provider/event_collectors/install/splunk"
-	"github.com/p0-security/terraform-provider-p0/internal/provider/resources"
 	installaws "github.com/p0-security/terraform-provider-p0/internal/provider/resources/install/aws"
 	installazure "github.com/p0-security/terraform-provider-p0/internal/provider/resources/install/azure"
 	installgcp "github.com/p0-security/terraform-provider-p0/internal/provider/resources/install/gcp"
 	installokta "github.com/p0-security/terraform-provider-p0/internal/provider/resources/install/okta"
 	installssh "github.com/p0-security/terraform-provider-p0/internal/provider/resources/install/ssh"
+	routingrules "github.com/p0-security/terraform-provider-p0/internal/provider/resources/routing_rules"
 )
 
 // Ensure P0Provider satisfies various provider interfaces.
@@ -111,7 +111,7 @@ func (p *P0Provider) Configure(ctx context.Context, req provider.ConfigureReques
 
 func (p *P0Provider) Resources(ctx context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
-		resources.NewRoutingRules,
+		routingrules.NewRoutingRules,
 		installaws.NewAwsIamWrite,
 		installaws.NewIamWriteStagedAws,
 		installazure.NewAzure,

--- a/internal/provider/resources/routing_rules/common.go
+++ b/internal/provider/resources/routing_rules/common.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2025 P0 Security, Inc
+// SPDX-License-Identifier: MPL-2.0
+
+package routingrules
+
+type RequestorModel struct {
+	Directory *string `json:"directory" tfsdk:"directory"`
+	Id        *string `json:"id" tfsdk:"id"`
+	Label     *string `json:"label" tfsdk:"label"`
+	Type      string  `json:"type" tfsdk:"type"`
+	Uid       *string `json:"uid" tfsdk:"uid"`
+}
+
+type ResourceFilterModel struct {
+	Effect  string  `json:"effect" tfsdk:"effect"`
+	Key     *string `json:"key" tfsdk:"key"`
+	Pattern *string `json:"pattern" tfsdk:"pattern"`
+	Value   *bool   `json:"value" tfsdk:"value"`
+}
+
+type ResourceModel struct {
+	Filters *map[string]ResourceFilterModel `json:"filters" tfsdk:"filters"`
+	Service *string                         `json:"service" tfsdk:"service"`
+	Type    string                          `json:"type" tfsdk:"type"`
+}
+
+type ApprovalOptionsModel struct {
+	AllowOneParty *bool `json:"allowOneParty" tfsdk:"allow_one_party"`
+	RequireReason *bool `json:"requireReason" tfsdk:"require_reason"`
+}
+
+type ApprovalModel struct {
+	Directory       *string               `json:"directory" tfsdk:"directory"`
+	Id              *string               `json:"id" tfsdk:"id"`
+	Integration     *string               `json:"integration" tfsdk:"integration"`
+	Label           *string               `json:"label" tfsdk:"label"`
+	ProfileProperty *string               `json:"profileProperty" tfsdk:"profile_property"`
+	Options         *ApprovalOptionsModel `json:"options" tfsdk:"options"`
+	Services        *[]string             `json:"services" tfsdk:"services"`
+	Type            string                `json:"type" tfsdk:"type"`
+}
+
+type RoutingRuleModel struct {
+	Requestor RequestorModel  `json:"requestor" tfsdk:"requestor"`
+	Resource  ResourceModel   `json:"resource" tfsdk:"resource"`
+	Approval  []ApprovalModel `json:"approval" tfsdk:"approval"`
+}
+
+var False = false


### PR DESCRIPTION
* Move the license rule reource to its own module
* Split out common code to common.go

This is in preparation for managing individual license rules via Terraform.