### PR TITLE
ENG-3916 Support concurrent updates of routing rules

### DIFF
--- a/docs/resources/routing_rule.md
+++ b/docs/resources/routing_rule.md
@@ -53,10 +53,6 @@ resource "p0_routing_rule" "example" {
 - `requestor` (Attributes) Controls who has access. See [the Requestor docs](https://docs.p0.dev/just-in-time-access/request-routing#requestor). (see [below for nested schema](#nestedatt--requestor))
 - `resource` (Attributes) Controls what is accessed. See [the Resource docs](https://docs.p0.dev/just-in-time-access/request-routing#resource). (see [below for nested schema](#nestedatt--resource))
 
-### Optional
-
-- `version` (String) Routing rule version
-
 <a id="nestedatt--approval"></a>
 ### Nested Schema for `approval`
 

--- a/internal/provider/resources/routing_rules/common.go
+++ b/internal/provider/resources/routing_rules/common.go
@@ -45,9 +45,16 @@ type ApprovalModel struct {
 	Type            string                `json:"type" tfsdk:"type"`
 }
 
+type RoutingRuleModel struct {
+	Name      *string         `json:"name" tfsdk:"name"`
+	Requestor *RequestorModel `json:"requestor" tfsdk:"requestor"`
+	Resource  *ResourceModel  `json:"resource" tfsdk:"resource"`
+	Approval  []ApprovalModel `json:"approval" tfsdk:"approval"`
+}
+
 var False = false
 
-var requestorAttributes = schema.SingleNestedAttribute{
+var requestorAttribute = schema.SingleNestedAttribute{
 	Required:            true,
 	MarkdownDescription: `Controls who has access. See [the Requestor docs](https://docs.p0.dev/just-in-time-access/request-routing#requestor).`,
 	Attributes: map[string]schema.Attribute{
@@ -71,7 +78,7 @@ var requestorAttributes = schema.SingleNestedAttribute{
 	},
 }
 
-var resourceAttributes = schema.SingleNestedAttribute{
+var resourceAttribute = schema.SingleNestedAttribute{
 	Required:            true,
 	MarkdownDescription: `Controls what is accessed. See [the Resource docs](https://docs.p0.dev/just-in-time-access/request-routing#resource).`,
 	Attributes: map[string]schema.Attribute{

--- a/internal/provider/resources/routing_rules/routing_rules.go
+++ b/internal/provider/resources/routing_rules/routing_rules.go
@@ -34,13 +34,6 @@ type RoutingRulesModel struct {
 	Version types.String       `tfsdk:"version"`
 }
 
-type RoutingRuleModel struct {
-	Name      *string         `json:"name" tfsdk:"name"`
-	Requestor RequestorModel  `json:"requestor" tfsdk:"requestor"`
-	Resource  ResourceModel   `json:"resource" tfsdk:"resource"`
-	Approval  []ApprovalModel `json:"approval" tfsdk:"approval"`
-}
-
 // Need a separate representation for JSON data as version handling is different:
 // - In TF state, it may be present, unknown (during update), or null
 // - In JSON state, it is either present or null.
@@ -64,8 +57,8 @@ type WorkflowUpdateApi struct {
 
 var defaultRoutingRules = LatestRoutingRules{
 	Rule: []RoutingRuleModel{{
-		Requestor: RequestorModel{Type: "any"},
-		Resource:  ResourceModel{Type: "any"},
+		Requestor: &RequestorModel{Type: "any"},
+		Resource:  &ResourceModel{Type: "any"},
 		Approval: []ApprovalModel{{
 			Type:    "p0",
 			Options: &ApprovalOptionsModel{AllowOneParty: &False, RequireReason: &False}}},
@@ -90,8 +83,8 @@ See [the P0 request-routing docs](https://docs.p0.dev/just-in-time-access/reques
 							MarkdownDescription: "The name of the rule",
 							Required:            true,
 						},
-						"requestor": requestorAttributes,
-						"resource":  resourceAttributes,
+						"requestor": requestorAttribute,
+						"resource":  resourceAttribute,
 						"approval":  approvalAttribute,
 					},
 				},


### PR DESCRIPTION
Removed version field from API & Terraform, since version is not unique for each rule.