### PR TITLE
ENG-4998 Fix 400 error when creating gcp resource

### DIFF
--- a/internal/provider/resources/install/gcp/gcp.go
+++ b/internal/provider/resources/install/gcp/gcp.go
@@ -48,12 +48,20 @@ type gcpIamAssessmentMetadata struct {
 	OrganizationPermissions []string `json:"orgLevelPermissions" tfsdk:"organization"`
 }
 
+type gcpConfig struct {
+	Root struct {
+		Singleton struct {
+			OrganizationId string `json:"organizationId"`
+		} `json:"_"`
+	} `json:"root"`
+}
+
 type gcpApi struct {
 	Config struct {
 		Root struct {
 			Singleton struct {
 				OrganizationId      string  `json:"organizationId"`
-				ServiceAccountEmail *string `json:"serviceAccountEmail"`
+				ServiceAccountEmail *string `json:"serviceAccountEmail,omitempty"`
 			} `json:"_"`
 		} `json:"root"`
 	} `json:"config"`
@@ -210,16 +218,16 @@ func (r *Gcp) fromJson(ctx context.Context, diags *diag.Diagnostics, json any) a
 }
 
 func (r *Gcp) toJson(data any) any {
-	json := gcpApi{}
+	json := gcpConfig{}
 
 	datav, ok := data.(*gcpModel)
 	if !ok {
 		return nil
 	}
 
-	json.Config.Root.Singleton.OrganizationId = datav.OrganizationId.ValueString()
+	json.Root.Singleton.OrganizationId = datav.OrganizationId.ValueString()
 
-	return &json.Config
+	return &json
 }
 
 func (r *Gcp) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/provider/resources/install/gcp/gcp.go
+++ b/internal/provider/resources/install/gcp/gcp.go
@@ -61,7 +61,7 @@ type gcpApi struct {
 		Root struct {
 			Singleton struct {
 				OrganizationId      string  `json:"organizationId"`
-				ServiceAccountEmail *string `json:"serviceAccountEmail,omitempty"`
+				ServiceAccountEmail *string `json:"serviceAccountEmail"`
 			} `json:"_"`
 		} `json:"root"`
 	} `json:"config"`


### PR DESCRIPTION
The provider was sending a nil serviceAccountEmail to the P0 backend, which resulted in a 400 error.

Modified gcp resource to use a different payload when creating the resource.