### PR TITLE
Add effect property to routing rule group matching

### DIFF
--- a/docs/resources/routing_rule.md
+++ b/docs/resources/routing_rule.md
@@ -72,6 +72,9 @@ Required:
 Optional:
 
 - `directory` (String) May only be used if 'type' is 'requestor-profile'. One of "azure-ad", "okta", or "workspace".
+- `effect` (String) The filter effect. May be one of:
+	 - 'keep': Access rule only applies when a requestor is a member of any of the specified groups
+	 - 'remove': Access rule only applies when a requestor is _not_ a member of any of the specified groups
 - `groups` (Attributes List) May only be used if 'type' is 'group'. If the user is a member of any of these groups, the rule will match. (see [below for nested schema](#nestedatt--approval--groups))
 - `integration` (String) May only be used if 'type' is 'auto' or 'escalation'. Possible values:
 - 'pagerduty': Access is granted if the requestor is on-call.
@@ -114,6 +117,9 @@ Required:
 
 Optional:
 
+- `effect` (String) The filter effect. May be one of:
+	 - 'keep': Access rule only applies when a requestor is a member of any of the specified groups
+	 - 'remove': Access rule only applies when a requestor is _not_ a member of any of the specified groups
 - `groups` (Attributes List) May only be used if 'type' is 'group'. If the user is a member of any of these groups, the rule will match. (see [below for nested schema](#nestedatt--requestor--groups))
 - `uid` (String) May only be used if 'type' is 'user'. This is the user's email address.
 

--- a/docs/resources/routing_rules.md
+++ b/docs/resources/routing_rules.md
@@ -80,6 +80,9 @@ Required:
 Optional:
 
 - `directory` (String) May only be used if 'type' is 'requestor-profile'. One of "azure-ad", "okta", or "workspace".
+- `effect` (String) The filter effect. May be one of:
+	 - 'keep': Access rule only applies when a requestor is a member of any of the specified groups
+	 - 'remove': Access rule only applies when a requestor is _not_ a member of any of the specified groups
 - `groups` (Attributes List) May only be used if 'type' is 'group'. If the user is a member of any of these groups, the rule will match. (see [below for nested schema](#nestedatt--rule--approval--groups))
 - `integration` (String) May only be used if 'type' is 'auto' or 'escalation'. Possible values:
 - 'pagerduty': Access is granted if the requestor is on-call.
@@ -122,6 +125,9 @@ Required:
 
 Optional:
 
+- `effect` (String) The filter effect. May be one of:
+	 - 'keep': Access rule only applies when a requestor is a member of any of the specified groups
+	 - 'remove': Access rule only applies when a requestor is _not_ a member of any of the specified groups
 - `groups` (Attributes List) May only be used if 'type' is 'group'. If the user is a member of any of these groups, the rule will match. (see [below for nested schema](#nestedatt--rule--requestor--groups))
 - `uid` (String) May only be used if 'type' is 'user'. This is the user's email address.
 

--- a/internal/provider/resources/routing_rules/common.go
+++ b/internal/provider/resources/routing_rules/common.go
@@ -28,6 +28,13 @@ type RequestorModelV1 struct {
 	Uid    *string        `json:"uid" tfsdk:"uid"`
 }
 
+type RequestorModelV2 struct {
+	Type   string         `json:"type" tfsdk:"type"`
+	Groups []GroupModelV1 `json:"groups" tfsdk:"groups"`
+	Uid    *string        `json:"uid" tfsdk:"uid"`
+	Effect *string        `json:"effect" tfsdk:"effect"`
+}
+
 type ResourceFilterModel struct {
 	Effect  string  `json:"effect" tfsdk:"effect"`
 	Key     *string `json:"key" tfsdk:"key"`
@@ -67,6 +74,17 @@ type ApprovalModelV1 struct {
 	Type            string                `json:"type" tfsdk:"type"`
 }
 
+type ApprovalModelV2 struct {
+	Directory       *string               `json:"directory" tfsdk:"directory"`
+	Integration     *string               `json:"integration" tfsdk:"integration"`
+	Groups          []GroupModelV1        `json:"groups" tfsdk:"groups"`
+	ProfileProperty *string               `json:"profileProperty" tfsdk:"profile_property"`
+	Options         *ApprovalOptionsModel `json:"options" tfsdk:"options"`
+	Services        *[]string             `json:"services" tfsdk:"services"`
+	Type            string                `json:"type" tfsdk:"type"`
+	Effect          *string               `json:"effect" tfsdk:"effect"`
+}
+
 type RoutingRuleModelV0 struct {
 	Name      *string           `json:"name" tfsdk:"name"`
 	Requestor *RequestorModelV0 `json:"requestor" tfsdk:"requestor"`
@@ -81,7 +99,14 @@ type RoutingRuleModelV1 struct {
 	Approval  []ApprovalModelV1 `json:"approval" tfsdk:"approval"`
 }
 
-const currentSchemaVersion int64 = 1
+type RoutingRuleModelV2 struct {
+	Name      *string           `json:"name" tfsdk:"name"`
+	Requestor *RequestorModelV2 `json:"requestor" tfsdk:"requestor"`
+	Resource  *ResourceModel    `json:"resource" tfsdk:"resource"`
+	Approval  []ApprovalModelV2 `json:"approval" tfsdk:"approval"`
+}
+
+const currentSchemaVersion int64 = 2
 
 var False = false
 
@@ -89,7 +114,7 @@ func requestorAttribute(version int64) schema.SingleNestedAttribute {
 	return schema.SingleNestedAttribute{
 		Required:            true,
 		MarkdownDescription: `Controls who has access. See [the Requestor docs](https://docs.p0.dev/just-in-time-access/request-routing#requestor).`,
-		Attributes: AttachGroupAttributes(version,
+		Attributes: AttachGroupFilterEffectAttribute(version, AttachGroupAttributes(version,
 			map[string]schema.Attribute{
 				"type": schema.StringAttribute{
 					MarkdownDescription: `How P0 matches requestors:
@@ -99,7 +124,7 @@ func requestorAttribute(version int64) schema.SingleNestedAttribute {
 					Required: true,
 				},
 				"uid": schema.StringAttribute{MarkdownDescription: `May only be used if 'type' is 'user'. This is the user's email address.`, Optional: true},
-			}),
+			})),
 	}
 }
 
@@ -155,7 +180,7 @@ func approvalAttribute(version int64) schema.ListNestedAttribute {
 		MarkdownDescription: `Determines access requirements. See [the Approval docs](https://docs.p0.dev/just-in-time-access/request-routing#approval).`,
 		Required:            true,
 		NestedObject: schema.NestedAttributeObject{
-			Attributes: AttachGroupAttributes(version, map[string]schema.Attribute{
+			Attributes: AttachGroupFilterEffectAttribute(version, AttachGroupAttributes(version, map[string]schema.Attribute{
 				"directory": schema.StringAttribute{
 					MarkdownDescription: `May only be used if 'type' is 'requestor-profile'. One of "azure-ad", "okta", or "workspace".`,
 					Optional:            true,
@@ -199,7 +224,7 @@ func approvalAttribute(version int64) schema.ListNestedAttribute {
     - 'p0': Access may be granted by any user with the P0 "approver" role (defined in the P0 app)`,
 					Required: true,
 				},
-			}),
+			})),
 		},
 	}
 }

--- a/internal/provider/resources/routing_rules/group.go
+++ b/internal/provider/resources/routing_rules/group.go
@@ -60,3 +60,21 @@ func AttachGroupAttributes(version int64, attributes map[string]schema.Attribute
 	}
 	return attributes
 }
+
+func AttachGroupFilterEffectAttribute(version int64, attributes map[string]schema.Attribute) map[string]schema.Attribute {
+	switch version {
+	case 0:
+	case 1:
+		return attributes
+	default:
+		{
+			attributes["effect"] = schema.StringAttribute{
+				MarkdownDescription: `The filter effect. May be one of:
+	 - 'keep': Access rule only applies when a requestor is a member of any of the specified groups
+	 - 'remove': Access rule only applies when a requestor is _not_ a member of any of the specified groups`,
+				Optional: true,
+			}
+		}
+	}
+	return attributes
+}


### PR DESCRIPTION
Adds an "effect" property to requestors and approvals of type: "group" that is either valued as "keep" or "remove".

Validated migration by:
- Clearing any existing terraform state
- Updating local dev database routing rules to not have "effect" properties
- Switching this repo to main branch, building, and installing
- Run terraform import to read from the configured routing rules
- Add routing rules resource block to terraform config file (without "effect" properties)
- Switching this repo to this branch, building, and installing
- Run terraform plan and terraform apply. API backend should reject due to missing properties
- Add "effect" properties to terraform config file
- Run terraform plan and terraform apply. Should be accepted now.
