### PR TITLE
Add optional access type property to routing rules resource model

### DIFF
--- a/docs/resources/routing_rule.md
+++ b/docs/resources/routing_rule.md
@@ -148,6 +148,7 @@ Required:
 
 Optional:
 
+- `access_type` (String) May only be used if 'type' is 'integration' and must be a valid access type for a given service integration. Defaults to 'any' if not specified.
 - `filters` (Attributes Map) May only be used if 'type' is 'integration'. Available filters depend on the value of 'service'.
 See [the Resource docs](https://docs.p0.dev/just-in-time-access/request-routing#resource) for a list of available filters. (see [below for nested schema](#nestedatt--resource--filters))
 - `service` (String) May only be used if 'type' is 'integration'.

--- a/docs/resources/routing_rule.md
+++ b/docs/resources/routing_rule.md
@@ -148,7 +148,7 @@ Required:
 
 Optional:
 
-- `access_type` (String) May only be used if 'type' is 'integration' and must be a valid access type for a given service integration. Defaults to 'any' if not specified.
+- `access_type` (String) May only be used if 'type' is 'integration' and must be a valid access type for a given service integration or 'any'. Defaults to 'any' if not specified.
 - `filters` (Attributes Map) May only be used if 'type' is 'integration'. Available filters depend on the value of 'service'.
 See [the Resource docs](https://docs.p0.dev/just-in-time-access/request-routing#resource) for a list of available filters. (see [below for nested schema](#nestedatt--resource--filters))
 - `service` (String) May only be used if 'type' is 'integration'.

--- a/docs/resources/routing_rules.md
+++ b/docs/resources/routing_rules.md
@@ -156,7 +156,7 @@ Required:
 
 Optional:
 
-- `access_type` (String) May only be used if 'type' is 'integration' and must be a valid access type for a given service integration. Defaults to 'any' if not specified.
+- `access_type` (String) May only be used if 'type' is 'integration' and must be a valid access type for a given service integration or 'any'. Defaults to 'any' if not specified.
 - `filters` (Attributes Map) May only be used if 'type' is 'integration'. Available filters depend on the value of 'service'.
 See [the Resource docs](https://docs.p0.dev/just-in-time-access/request-routing#resource) for a list of available filters. (see [below for nested schema](#nestedatt--rule--resource--filters))
 - `service` (String) May only be used if 'type' is 'integration'.

--- a/docs/resources/routing_rules.md
+++ b/docs/resources/routing_rules.md
@@ -156,6 +156,7 @@ Required:
 
 Optional:
 
+- `access_type` (String) May only be used if 'type' is 'integration' and must be a valid access type for a given service integration. Defaults to 'any' if not specified.
 - `filters` (Attributes Map) May only be used if 'type' is 'integration'. Available filters depend on the value of 'service'.
 See [the Resource docs](https://docs.p0.dev/just-in-time-access/request-routing#resource) for a list of available filters. (see [below for nested schema](#nestedatt--rule--resource--filters))
 - `service` (String) May only be used if 'type' is 'integration'.

--- a/internal/provider/resources/routing_rules/common.go
+++ b/internal/provider/resources/routing_rules/common.go
@@ -174,7 +174,7 @@ See [the Resource docs](https://docs.p0.dev/just-in-time-access/request-routing#
 			Required: true,
 		},
 		"access_type": schema.StringAttribute{
-			MarkdownDescription: `May only be used if 'type' is 'integration' and must be a valid access type for a given service integration. Defaults to 'any' if not specified.`,
+			MarkdownDescription: `May only be used if 'type' is 'integration' and must be a valid access type for a given service integration or 'any'. Defaults to 'any' if not specified.`,
 			Optional:            true,
 		},
 	},

--- a/internal/provider/resources/routing_rules/common.go
+++ b/internal/provider/resources/routing_rules/common.go
@@ -43,9 +43,10 @@ type ResourceFilterModel struct {
 }
 
 type ResourceModel struct {
-	Filters *map[string]ResourceFilterModel `json:"filters" tfsdk:"filters"`
-	Service *string                         `json:"service" tfsdk:"service"`
-	Type    string                          `json:"type" tfsdk:"type"`
+	Type       string                          `json:"type" tfsdk:"type"`
+	Service    *string                         `json:"service" tfsdk:"service"`
+	AccessType *string                         `json:"accessType" tfsdk:"access_type"`
+	Filters    *map[string]ResourceFilterModel `json:"filters" tfsdk:"filters"`
 }
 
 type ApprovalOptionsModel struct {
@@ -171,6 +172,10 @@ See [the Resource docs](https://docs.p0.dev/just-in-time-access/request-routing#
     - 'any': Any resource
     - 'integration': Only resources within a specified integration`,
 			Required: true,
+		},
+		"access_type": schema.StringAttribute{
+			MarkdownDescription: `May only be used if 'type' is 'integration' and must be a valid access type for a given service integration. Defaults to 'any' if not specified.`,
+			Optional:            true,
 		},
 	},
 }


### PR DESCRIPTION
Allows the access type in routing rules to be managed by terraform. Manually validated that it works with existing tfstate files prior to this change. Note that an upgrader is not necessary because this was a backwards-compatible change.