### PR TITLE
Rename "approver" role to "security reviewer"

### DIFF
--- a/docs/resources/routing_rule.md
+++ b/docs/resources/routing_rule.md
@@ -67,7 +67,7 @@ Required:
     - 'group': Access may be granted by any member of the defined directory group
     - 'persistent': Access is always granted
     - 'requestor-profile': Allows approval by a user specified by a field in the requestor's IDP profile
-    - 'p0': Access may be granted by any user with the P0 "approver" role (defined in the P0 app)
+    - 'p0': Access may be granted by any user with the P0 "security reviewer" role (defined in the P0 app)
 
 Optional:
 

--- a/docs/resources/routing_rules.md
+++ b/docs/resources/routing_rules.md
@@ -75,7 +75,7 @@ Required:
     - 'group': Access may be granted by any member of the defined directory group
     - 'persistent': Access is always granted
     - 'requestor-profile': Allows approval by a user specified by a field in the requestor's IDP profile
-    - 'p0': Access may be granted by any user with the P0 "approver" role (defined in the P0 app)
+    - 'p0': Access may be granted by any user with the P0 "security reviewer" role (defined in the P0 app)
 
 Optional:
 

--- a/internal/provider/resources/routing_rules/common.go
+++ b/internal/provider/resources/routing_rules/common.go
@@ -221,7 +221,7 @@ func approvalAttribute(version int64) schema.ListNestedAttribute {
     - 'group': Access may be granted by any member of the defined directory group
     - 'persistent': Access is always granted
     - 'requestor-profile': Allows approval by a user specified by a field in the requestor's IDP profile
-    - 'p0': Access may be granted by any user with the P0 "approver" role (defined in the P0 app)`,
+    - 'p0': Access may be granted by any user with the P0 "security reviewer" role (defined in the P0 app)`,
 					Required: true,
 				},
 			})),

--- a/internal/provider/resources/routing_rules/routing_rules.go
+++ b/internal/provider/resources/routing_rules/routing_rules.go
@@ -268,7 +268,7 @@ func (rules *RoutingRules) Delete(ctx context.Context, req resource.DeleteReques
 	diag.AddWarning(
 		"Routing rules are not deleted",
 		`Routing rules can not be deleted. Deleting the routing_rules resource instead restores rules to the P0 default rules.
-These rules allow all principals to request access to all resources, with manual approval by P0 approvers.`,
+These rules allow all principals to request access to all resources, with manual approval by users defined as 'security reviewers' in P0.`,
 	)
 
 	// Set workflow to default rules


### PR DESCRIPTION
Updates the Terraform documentation to refer to the newly renamed "approver" role by it's new name of "security reviewer".