### PR TITLE
Add AWS partition attribute to AWS IAM install resources

### DIFF
--- a/docs/resources/aws_iam_write.md
+++ b/docs/resources/aws_iam_write.md
@@ -84,6 +84,7 @@ resource "p0_aws_iam_write" "example" {
 ### Optional
 
 - `label` (String) The AWS account's alias (if available)
+- `partition` (String) The AWS partition (aws or aws-us-gov). Defaults to aws if not specified.
 
 ### Read-Only
 

--- a/docs/resources/aws_iam_write_staged.md
+++ b/docs/resources/aws_iam_write_staged.md
@@ -28,6 +28,10 @@ resource "p0_aws_iam_write_staged" "example" {
 
 - `id` (String) The AWS account ID
 
+### Optional
+
+- `partition` (String) The AWS partition (aws or aws-us-gov). Defaults to aws if not specified.
+
 ### Read-Only
 
 - `label` (String) The AWS account's alias (if available)

--- a/internal/common/install.go
+++ b/internal/common/install.go
@@ -29,6 +29,10 @@ var StateAttribute = schema.StringAttribute{
 // Order matters here; components installed in this order.
 var InstallSteps = []string{Verify, Config}
 
+type AwsPartition struct {
+	Type *string `json:"type"`
+}
+
 type Install struct {
 	// This Integration's key
 	Integration string
@@ -78,7 +82,7 @@ func (i *Install) EnsureConfig(ctx context.Context, diags *diag.Diagnostics, pla
 //
 //	var data ItemConfigurationModel
 //	var json ConfigurationApiResponseJson
-func (i *Install) Stage(ctx context.Context, diags *diag.Diagnostics, plan *tfsdk.Plan, state *tfsdk.State, json any, model any) {
+func (i *Install) Stage(ctx context.Context, diags *diag.Diagnostics, plan *tfsdk.Plan, state *tfsdk.State, json any, model any, inputJson any) {
 	diags.Append(plan.Get(ctx, model)...)
 	if diags.HasError() {
 		return
@@ -90,7 +94,7 @@ func (i *Install) Stage(ctx context.Context, diags *diag.Diagnostics, plan *tfsd
 		return
 	}
 
-	_, err := i.ProviderData.Put(i.itemPath(*id), &struct{}{}, json)
+	_, err := i.ProviderData.Put(i.itemPath(*id), inputJson, json)
 	if err != nil {
 		diags.AddError(fmt.Sprintf("Could not stage %s component", i.Component), fmt.Sprintf("Error: %s", err))
 	}

--- a/internal/provider/event_collectors/install/splunk/audit_logs.go
+++ b/internal/provider/event_collectors/install/splunk/audit_logs.go
@@ -236,7 +236,7 @@ func (s *AuditLogs) Create(ctx context.Context, req resource.CreateRequest, resp
 	var model auditLogsModel
 
 	s.installer.EnsureConfig(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &model)
-	s.installer.Stage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &api, &model)
+	s.installer.Stage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &api, &model, &struct{}{})
 	s.installer.UpsertFromStage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &api, &model)
 
 	// manually set the token cleartext attribute

--- a/internal/provider/resources/install/aws/common.go
+++ b/internal/provider/resources/install/aws/common.go
@@ -15,6 +15,7 @@ const (
 var Components = []string{installresources.IamWrite, Inventory}
 
 var AwsAccountIdRegex = regexp.MustCompile(`^\d{12}$`)
+var AwsPartitionRegex = regexp.MustCompile(`^(aws|aws-us-gov)$`)
 var AwsIdpPattern = regexp.MustCompile(`^[\w.-/]+$`)
 var OktaAppIdRegex = regexp.MustCompile(`^0o\w+$`)
 

--- a/internal/provider/resources/install/azure/azure_app.go
+++ b/internal/provider/resources/install/azure/azure_app.go
@@ -126,7 +126,7 @@ func (r *AzureApp) Configure(ctx context.Context, req resource.ConfigureRequest,
 func (s *AzureApp) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var json azureAppJsonApi
 	var data azureAppModel
-	s.installer.Stage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &json, &data)
+	s.installer.Stage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &json, &data, &struct{}{})
 	s.installer.UpsertFromStage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &json, &data)
 }
 

--- a/internal/provider/resources/install/azure/iam_write_staged.go
+++ b/internal/provider/resources/install/azure/iam_write_staged.go
@@ -166,7 +166,7 @@ func (r *AzureIamWriteStaged) Configure(ctx context.Context, req resource.Config
 func (s *AzureIamWriteStaged) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var json AzureIamWriteStagedApi
 	var data AzureIamWriteStagedModel
-	s.installer.Stage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &json, &data)
+	s.installer.Stage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &json, &data, &struct{}{})
 }
 
 func (s *AzureIamWriteStaged) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {

--- a/internal/provider/resources/install/gcp/access_logs.go
+++ b/internal/provider/resources/install/gcp/access_logs.go
@@ -52,7 +52,7 @@ func (r *GcpAccessLogs) Configure(ctx context.Context, req resource.ConfigureReq
 func (s *GcpAccessLogs) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var json gcpItemApi
 	var data gcpItemModel
-	s.installer.Stage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &json, &data)
+	s.installer.Stage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &json, &data, &struct{}{})
 	s.installer.UpsertFromStage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &json, &data)
 }
 

--- a/internal/provider/resources/install/gcp/iam_assessment_staged.go
+++ b/internal/provider/resources/install/gcp/iam_assessment_staged.go
@@ -135,7 +135,7 @@ func (r *GcpIamAssessmentStaged) Configure(ctx context.Context, req resource.Con
 func (s *GcpIamAssessmentStaged) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var json gcpIamAssessmentStagedApi
 	var data gcpIamAssessmentStagedModel
-	s.installer.Stage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &json, &data)
+	s.installer.Stage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &json, &data, &struct{}{})
 }
 
 func (s *GcpIamAssessmentStaged) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {

--- a/internal/provider/resources/install/gcp/iam_write_staged.go
+++ b/internal/provider/resources/install/gcp/iam_write_staged.go
@@ -127,7 +127,7 @@ func (r *GcpIamWriteStaged) Configure(ctx context.Context, req resource.Configur
 func (s *GcpIamWriteStaged) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var json gcpIamWriteStagedApi
 	var data gcpIamWriteStagedModel
-	s.installer.Stage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &json, &data)
+	s.installer.Stage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &json, &data, &struct{}{})
 }
 
 func (s *GcpIamWriteStaged) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {

--- a/internal/provider/resources/install/gcp/org_access_logs.go
+++ b/internal/provider/resources/install/gcp/org_access_logs.go
@@ -115,7 +115,7 @@ func (r *GcpOrgAccessLogs) Configure(ctx context.Context, req resource.Configure
 func (s *GcpOrgAccessLogs) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var json gcpOrgAccessLogsApi
 	var data gcpOrgAccessLogsModel
-	s.installer.Stage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &json, &data)
+	s.installer.Stage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &json, &data, &struct{}{})
 	s.installer.UpsertFromStage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &json, &data)
 }
 

--- a/internal/provider/resources/install/gcp/org_iam_assessment.go
+++ b/internal/provider/resources/install/gcp/org_iam_assessment.go
@@ -78,7 +78,7 @@ func (r *GcpOrgIamAssessment) Configure(ctx context.Context, req resource.Config
 func (s *GcpOrgIamAssessment) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var model gcpOrgIamAssessmentModel
 	var json gcpItemApi
-	s.installer.Stage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &json, &model)
+	s.installer.Stage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &json, &model, &struct{}{})
 	s.installer.UpsertFromStage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &json, &model)
 }
 

--- a/internal/provider/resources/install/gcp/security_perimeter_staged.go
+++ b/internal/provider/resources/install/gcp/security_perimeter_staged.go
@@ -214,7 +214,7 @@ func (s *GcpSecurityPerimeterStage) Create(ctx context.Context, req resource.Cre
 	var api gcpSecurityPerimeterStageApi
 	var model gcpSecurityPerimeterStageModel
 	s.installer.EnsureConfig(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &model)
-	s.installer.Stage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &api, &model)
+	s.installer.Stage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &api, &model, &struct{}{})
 }
 
 func (s *GcpSecurityPerimeterStage) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {

--- a/internal/provider/resources/install/gcp/sharing_restriction.go
+++ b/internal/provider/resources/install/gcp/sharing_restriction.go
@@ -50,7 +50,7 @@ func (r *GcpSharingRestriction) Configure(ctx context.Context, req resource.Conf
 func (s *GcpSharingRestriction) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var json gcpItemApi
 	var data gcpItemModel
-	s.installer.Stage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &json, &data)
+	s.installer.Stage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &json, &data, &struct{}{})
 	s.installer.UpsertFromStage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &json, &data)
 }
 

--- a/internal/provider/resources/install/okta/directory_listing_staged.go
+++ b/internal/provider/resources/install/okta/directory_listing_staged.go
@@ -132,7 +132,7 @@ func (r *OktaDirectoryListingStaged) Configure(ctx context.Context, req resource
 func (s *OktaDirectoryListingStaged) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var json oktaDirectoryListingStagedApi
 	var data oktaDirectoryListingStagedModel
-	s.installer.Stage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &json, &data)
+	s.installer.Stage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &json, &data, &struct{}{})
 }
 
 func (s *OktaDirectoryListingStaged) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {

--- a/internal/provider/resources/install/okta/group_assignment.go
+++ b/internal/provider/resources/install/okta/group_assignment.go
@@ -113,7 +113,7 @@ func (r *OktaGroupAssignment) toJson(data any) any {
 func (r *OktaGroupAssignment) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var json oktaGroupAssignmentApi
 	var data oktaGroupAssignmentModel
-	r.installer.Stage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &json, &data)
+	r.installer.Stage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &json, &data, &struct{}{})
 	r.installer.UpsertFromStage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &json, &data)
 }
 

--- a/internal/provider/resources/install/ssh/aws.go
+++ b/internal/provider/resources/install/ssh/aws.go
@@ -200,7 +200,7 @@ func (s *sshAwsIamWrite) Create(ctx context.Context, req resource.CreateRequest,
 	var data sshAwsIamWriteModel
 
 	s.installer.EnsureConfig(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &data)
-	s.installer.Stage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &json, &data)
+	s.installer.Stage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &json, &data, &struct{}{})
 	s.installer.UpsertFromStage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &json, &data)
 }
 

--- a/internal/provider/resources/install/ssh/azure.go
+++ b/internal/provider/resources/install/ssh/azure.go
@@ -232,7 +232,7 @@ func (s *sshAzureIamWrite) Create(ctx context.Context, req resource.CreateReques
 	var json sshAzureIamWriteApi
 	var data sshAzureIamWriteModel
 	s.installer.EnsureConfig(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &data)
-	s.installer.Stage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &json, &data)
+	s.installer.Stage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &json, &data, &struct{}{})
 	s.installer.UpsertFromStage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &json, &data)
 }
 

--- a/internal/provider/resources/install/ssh/gcp.go
+++ b/internal/provider/resources/install/ssh/gcp.go
@@ -189,7 +189,7 @@ func (s *sshGcpIamWrite) Create(ctx context.Context, req resource.CreateRequest,
 	var json sshGcpIamWriteApi
 	var data sshGcpIamWriteModel
 	s.installer.EnsureConfig(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &data)
-	s.installer.Stage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &json, &data)
+	s.installer.Stage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &json, &data, &struct{}{})
 	s.installer.UpsertFromStage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &json, &data)
 }
 


### PR DESCRIPTION
Add the `partition` attribute to the `aws_iam_write_staged` and `aws_iam_write` resources.
This is an optional attribute. If the value is missing it is simply not sent to the P0 backend, which handles defaulting it to `"aws"`.
The `partition` attribute has to be repeated on the `aws_iam_write` resource because the P0 backend expects the value to be passed again.

Example configuration:
```
resource "p0_aws_iam_write_staged" "iam_write_staged" {
  id        = var.aws_account_id
  partition = "aws-us-gov"
}

resource "p0_aws_iam_write" "iam_write" {
  id        = p0_aws_iam_write_staged.iam_write_staged.id
  partition = "aws-us-gov"
  login = {
    type   = "idc"
    parent = p0_aws_iam_write_staged.iam_write_staged.id
  }
}
```