### PR TITLE
Migrate Semgrep to centralized reusable workflow

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -14,4 +14,6 @@ on:
 jobs:
   semgrep:
     uses: p0-security/workflows-public/.github/workflows/semgrep-reusable.yml@main
-    secrets: inherit
+    secrets:
+      SEMGREP_RULES_APP_ID: ${{ secrets.SEMGREP_RULES_APP_ID }}
+      SEMGREP_RULES_APP_PRIVATE_KEY: ${{ secrets.SEMGREP_RULES_APP_PRIVATE_KEY }}

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -13,5 +13,5 @@ on:
 
 jobs:
   semgrep:
-    uses: p0-security/workflows/.github/workflows/semgrep-reusable.yml@main
+    uses: p0-security/workflows-public/.github/workflows/semgrep-reusable.yml@main
     secrets: inherit

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,25 +1,17 @@
-name: Semgrep
+name: Semgrep CI
+
 on:
-  workflow_dispatch: {}
   pull_request: {}
+  workflow_dispatch: {}
   push:
     branches:
       - main
     paths:
       - .github/workflows/semgrep.yml
   schedule:
-    - cron: 0 3 * * *
+    - cron: 0 1 * * *
+
 jobs:
   semgrep:
-    name: semgrep/ci
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    env:
-      SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
-    container:
-      image: semgrep/semgrep
-    if: (github.actor != 'dependabot[bot]')
-    steps:
-      - uses: actions/checkout@v6.0.2
-      - run: semgrep ci
+    uses: p0-security/workflows/.github/workflows/semgrep-reusable.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Replaces inline Semgrep job (using `SEMGREP_APP_TOKEN` + `semgrep ci`) with the org-wide reusable workflow from `p0-security/workflows`
- Picks up private org rules from `p0-semgrep-rules` via GitHub App
- Enables diff-aware scanning on PRs with baseline comparison

## Test plan
- [x] Confirm `SEMGREP_RULES_APP_ID` and `SEMGREP_RULES_APP_PRIVATE_KEY` are available as org secrets to this repo
- [x] Verify the Semgrep CI check passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)