### PR TITLE
switch to subscription id for azure ssh

### DIFF
--- a/docs/resources/ssh_azure.md
+++ b/docs/resources/ssh_azure.md
@@ -17,9 +17,8 @@ Installing SSH allows you to manage access to your virtual machines on Microsoft
 
 ```terraform
 locals {
-  management_group_id = "my-management-group"
-  subscription_id     = "12345678-1234-1234-1234-123456789012"
-  bastion_id          = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/sample-resource-group/providers/Microsoft.Network/bastionHosts/sample-bastion"
+  subscription_id = "12345678-1234-1234-1234-123456789012"
+  bastion_id      = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/sample-resource-group/providers/Microsoft.Network/bastionHosts/sample-bastion"
 
 }
 
@@ -30,7 +29,7 @@ provider "azurerm" {
 
 resource "azurerm_role_definition" "vm_admin_access" {
   name        = "Virtual Machine Administrator Access"
-  scope       = "/providers/Microsoft.Management/managementGroups/${local.management_group_id}"
+  scope       = "/subscriptions/${local.subscription_id}"
   description = "Grants a user read access to virtual machines and Sudo SSH access"
 
   permissions {
@@ -46,13 +45,13 @@ resource "azurerm_role_definition" "vm_admin_access" {
   }
 
   assignable_scopes = [
-    "/providers/Microsoft.Management/managementGroups/${local.management_group_id}"
+    "/subscriptions/${local.subscription_id}"
   ]
 }
 
 resource "azurerm_role_definition" "vm_standard_access" {
   name        = "Virtual Machine Standard Access"
-  scope       = "/providers/Microsoft.Management/managementGroups/${local.management_group_id}"
+  scope       = "/subscriptions/${local.subscription_id}"
   description = "Grants a user read access to virtual machines and SSH access"
 
   permissions {
@@ -67,7 +66,7 @@ resource "azurerm_role_definition" "vm_standard_access" {
   }
 
   assignable_scopes = [
-    "/providers/Microsoft.Management/managementGroups/${local.management_group_id}"
+    "/subscriptions/${local.subscription_id}"
   ]
 }
 
@@ -78,7 +77,7 @@ resource "p0_ssh_azure" "example" {
   is_sudo_enabled         = true
   group_key               = "resource-group"
   bastion_id              = local.bastion_id
-  management_group_id     = local.management_group_id
+  subscription_id         = local.subscription_id
 }
 ```
 
@@ -89,8 +88,8 @@ resource "p0_ssh_azure" "example" {
 
 - `admin_access_role_id` (String) The ID of the Azure role that grants admin access to the virtual machines
 - `bastion_id` (String) The ID of the Azure Bastion that provides secure RDP and SSH access to the virtual machines
-- `management_group_id` (String) The Azure Management Group ID
 - `standard_access_role_id` (String) The ID of the Azure role that grants standard access to the virtual machines
+- `subscription_id` (String) The Azure Subscription ID
 
 ### Optional
 
@@ -99,7 +98,7 @@ resource "p0_ssh_azure" "example" {
 
 ### Read-Only
 
-- `label` (String) The Azure Management Group label (if available)
+- `label` (String) The Azure Subscription label (if available)
 - `state` (String) This item's install progress in the P0 application:
 	- 'stage': The item has been staged for installation
 	- 'configure': The item is available to be added to P0, and may be configured

--- a/examples/resources/p0_ssh_azure/resource.tf
+++ b/examples/resources/p0_ssh_azure/resource.tf
@@ -1,7 +1,6 @@
 locals {
-  management_group_id = "my-management-group"
-  subscription_id     = "12345678-1234-1234-1234-123456789012"
-  bastion_id          = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/sample-resource-group/providers/Microsoft.Network/bastionHosts/sample-bastion"
+  subscription_id = "12345678-1234-1234-1234-123456789012"
+  bastion_id      = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/sample-resource-group/providers/Microsoft.Network/bastionHosts/sample-bastion"
 
 }
 
@@ -12,7 +11,7 @@ provider "azurerm" {
 
 resource "azurerm_role_definition" "vm_admin_access" {
   name        = "Virtual Machine Administrator Access"
-  scope       = "/providers/Microsoft.Management/managementGroups/${local.management_group_id}"
+  scope       = "/subscriptions/${local.subscription_id}"
   description = "Grants a user read access to virtual machines and Sudo SSH access"
 
   permissions {
@@ -28,13 +27,13 @@ resource "azurerm_role_definition" "vm_admin_access" {
   }
 
   assignable_scopes = [
-    "/providers/Microsoft.Management/managementGroups/${local.management_group_id}"
+    "/subscriptions/${local.subscription_id}"
   ]
 }
 
 resource "azurerm_role_definition" "vm_standard_access" {
   name        = "Virtual Machine Standard Access"
-  scope       = "/providers/Microsoft.Management/managementGroups/${local.management_group_id}"
+  scope       = "/subscriptions/${local.subscription_id}"
   description = "Grants a user read access to virtual machines and SSH access"
 
   permissions {
@@ -49,7 +48,7 @@ resource "azurerm_role_definition" "vm_standard_access" {
   }
 
   assignable_scopes = [
-    "/providers/Microsoft.Management/managementGroups/${local.management_group_id}"
+    "/subscriptions/${local.subscription_id}"
   ]
 }
 
@@ -60,5 +59,5 @@ resource "p0_ssh_azure" "example" {
   is_sudo_enabled         = true
   group_key               = "resource-group"
   bastion_id              = local.bastion_id
-  management_group_id     = local.management_group_id
+  subscription_id         = local.subscription_id
 }

--- a/internal/provider/resources/install/ssh/azure.go
+++ b/internal/provider/resources/install/ssh/azure.go
@@ -36,7 +36,7 @@ type sshAzureIamWriteModel struct {
 	GroupKey             types.String `tfsdk:"group_key" json:"groupKey,omitempty"`
 	IsSudoEnabled        types.Bool   `tfsdk:"is_sudo_enabled" json:"isSudoEnabled,omitempty"`
 	Label                types.String `tfsdk:"label" json:"label,omitempty"`
-	ManagementGroupId    types.String `tfsdk:"management_group_id" json:"managementGroupId,omitempty"`
+	SubscriptionId       types.String `tfsdk:"subscription_id" json:"subscriptionId,omitempty"`
 	StandardAccessRoleId types.String `tfsdk:"standard_access_role_id" json:"standardAccessRoleId,omitempty"`
 	State                types.String `tfsdk:"state" json:"state,omitempty"`
 }
@@ -47,7 +47,7 @@ type sshAzureIamWriteJson struct {
 	GroupKey             *string `json:"groupKey"`
 	IsSudoEnabled        *bool   `json:"isSudoEnabled,omitempty"`
 	Label                *string `json:"label,omitempty"`
-	ManagementGroupId    *string `json:"managementGroupId"`
+	SubscriptionId       *string `json:"subscriptionId"`
 	StandardAccessRoleId *string `json:"standardAccessRoleId"`
 	State                string  `json:"state"`
 }
@@ -92,10 +92,10 @@ Installing SSH allows you to manage access to your virtual machines on Microsoft
 			},
 			"label": schema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: "The Azure Management Group label (if available)",
+				MarkdownDescription: "The Azure Subscription label (if available)",
 			},
-			"management_group_id": schema.StringAttribute{
-				MarkdownDescription: "The Azure Management Group ID",
+			"subscription_id": schema.StringAttribute{
+				MarkdownDescription: "The Azure Subscription ID",
 				Required:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
@@ -132,7 +132,7 @@ func (r *sshAzureIamWrite) getId(data any) *string {
 		return nil
 	}
 
-	str := fmt.Sprintf("%s%s", azurePrefix, model.ManagementGroupId.ValueString())
+	str := fmt.Sprintf("%s%s", azurePrefix, model.SubscriptionId.ValueString())
 	return &str
 }
 
@@ -152,7 +152,7 @@ func (r *sshAzureIamWrite) fromJson(ctx context.Context, diags *diag.Diagnostics
 	}
 
 	data.State = types.StringValue(jsonv.State)
-	data.ManagementGroupId = types.StringValue(strings.TrimPrefix(id, azurePrefix))
+	data.SubscriptionId = types.StringValue(strings.TrimPrefix(id, azurePrefix))
 
 	if jsonv.Label != nil {
 		data.Label = types.StringValue(*jsonv.Label)
@@ -251,5 +251,5 @@ func (s *sshAzureIamWrite) Update(ctx context.Context, req resource.UpdateReques
 }
 
 func (s *sshAzureIamWrite) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("management_group_id"), req, resp)
+	resource.ImportStatePassthroughID(ctx, path.Root("subscription_id"), req, resp)
 }


### PR DESCRIPTION
## Summary
- `p0_ssh_azure` previously took a `management_group_id` and rendered Azure role definitions/assignments at management-group scope, but the P0 app's `verifyRoleScopes` strictly requires `assignableScopes` of `/subscriptions/{id}` and rejects everything else — so SSH-on-Azure installs via Terraform fail end-to-end against the app.
- This PR brings `p0_ssh_azure` in line with `p0_azure_iam_write` and `p0_azure_bastion_host`, which already scope at the subscription level. The user-facing field becomes `subscription_id`; the `azure:` SSH integration-key prefix is unchanged.
- Updated example HCL (`scope`/`assignable_scopes` now use `/subscriptions/${local.subscription_id}`) and regenerated `docs/resources/ssh_azure.md` via `go generate ./...`.

## Breaking change
- `p0_ssh_azure.management_group_id` is removed. Existing state referencing this field will need to be recreated. No migration shim is provided — the resource was non-functional against the app prior to this fix.

## Out of scope
- Loosening the app's `verifyRoleScopes` to also accept management-group scopes. If a customer needs MG-level installs  that would be a separate change in the P0 app, plus re-introducing MG support here.
