### PR TITLE
add support for api key parameter

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,16 +3,18 @@
 page_title: "p0 Provider"
 description: |-
   Configures a P0 organization. Requires a P0 account. Go to https://p0.app to create an account.
-  You must also configure a P0 API token (on your P0 app "/settings" page). Then run Terraform with your API token in
-  the P0_API_TOKEN environment variable.
+  You must also configure a P0 API token (on your P0 app "/settings" page). Pass it via the api_token provider
+  attribute, or by setting the P0_API_TOKEN environment variable. The api_token attribute takes
+  precedence when both are set.
 ---
 
 # p0 Provider
 
 Configures a P0 organization. Requires a P0 account. Go to https://p0.app to create an account.
 
-You must also configure a P0 API token (on your P0 app "/settings" page). Then run Terraform with your API token in
-the P0_API_TOKEN environment variable.
+You must also configure a P0 API token (on your P0 app "/settings" page). Pass it via the `api_token` provider
+attribute, or by setting the `P0_API_TOKEN` environment variable. The `api_token` attribute takes
+precedence when both are set.
 
 ## Example Usage
 
@@ -31,4 +33,5 @@ provider "p0" {
 
 ### Optional
 
+- `api_token` (String, Sensitive) Your P0 API token. If unset, falls back to the `P0_API_TOKEN` environment variable.
 - `host` (String) Your P0 application API host (defaults to `https://api.p0.app`)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -10,6 +10,7 @@ import (
 	"os"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/function"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
@@ -79,6 +80,25 @@ precedence when both are set.`,
 	}
 }
 
+func resolveApiToken(apiToken types.String, org string, diags *diag.Diagnostics) string {
+	var token string
+	if !apiToken.IsNull() && !apiToken.IsUnknown() {
+		token = apiToken.ValueString()
+	} else {
+		token = os.Getenv("P0_API_TOKEN")
+	}
+	if token == "" {
+		diags.AddError(
+			"No P0 API token configured",
+			fmt.Sprintf(
+				"A P0 API token is required to use the P0 Terraform provider. To create a token, navigate to https://p0.app/o/%s/settings. Pass your token via the `api_token` provider attribute or the P0_API_TOKEN environment variable.",
+				org,
+			),
+		)
+	}
+	return token
+}
+
 func (p *P0Provider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
 	var model P0ProviderModel
 
@@ -91,21 +111,7 @@ func (p *P0Provider) Configure(ctx context.Context, req provider.ConfigureReques
 		)
 	}
 
-	var api_token string
-	if !model.ApiToken.IsNull() && !model.ApiToken.IsUnknown() {
-		api_token = model.ApiToken.ValueString()
-	} else {
-		api_token = os.Getenv("P0_API_TOKEN")
-	}
-	if api_token == "" {
-		resp.Diagnostics.AddError(
-			"No P0 API token configured",
-			fmt.Sprintf(
-				"A P0 API token is required to use the P0 Terraform provider. To create a token, navigate to https://p0.app/o/%s/settings. Pass your token via the `api_token` provider attribute or the P0_API_TOKEN environment variable.",
-				model.Org.ValueString(),
-			),
-		)
-	}
+	api_token := resolveApiToken(model.ApiToken, model.Org.ValueString(), &resp.Diagnostics)
 
 	p0_host := model.Host.ValueString()
 	if p0_host == "" {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -44,8 +44,9 @@ type P0Provider struct {
 
 // P0ProviderModel describes the provider data model.
 type P0ProviderModel struct {
-	Host types.String `tfsdk:"host"`
-	Org  types.String `tfsdk:"org"`
+	Host     types.String `tfsdk:"host"`
+	Org      types.String `tfsdk:"org"`
+	ApiToken types.String `tfsdk:"api_token"`
 }
 
 func (p *P0Provider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
@@ -57,8 +58,9 @@ func (p *P0Provider) Schema(ctx context.Context, req provider.SchemaRequest, res
 	resp.Schema = schema.Schema{
 		MarkdownDescription: `Configures a P0 organization. Requires a P0 account. Go to https://p0.app to create an account.
 
-You must also configure a P0 API token (on your P0 app "/settings" page). Then run Terraform with your API token in
-the P0_API_TOKEN environment variable.`,
+You must also configure a P0 API token (on your P0 app "/settings" page). Pass it via the ` + "`api_token`" + ` provider
+attribute, or by setting the ` + "`P0_API_TOKEN`" + ` environment variable. The ` + "`api_token`" + ` attribute takes
+precedence when both are set.`,
 		Attributes: map[string]schema.Attribute{
 			"host": schema.StringAttribute{
 				MarkdownDescription: "Your P0 application API host (defaults to `https://api.p0.app`)",
@@ -67,6 +69,11 @@ the P0_API_TOKEN environment variable.`,
 			"org": schema.StringAttribute{
 				MarkdownDescription: "Your P0 organization identifier",
 				Required:            true,
+			},
+			"api_token": schema.StringAttribute{
+				MarkdownDescription: "Your P0 API token. If unset, falls back to the `P0_API_TOKEN` environment variable.",
+				Optional:            true,
+				Sensitive:           true,
 			},
 		},
 	}
@@ -84,12 +91,15 @@ func (p *P0Provider) Configure(ctx context.Context, req provider.ConfigureReques
 		)
 	}
 
-	api_token := os.Getenv("P0_API_TOKEN")
+	api_token := model.ApiToken.ValueString()
+	if api_token == "" {
+		api_token = os.Getenv("P0_API_TOKEN")
+	}
 	if api_token == "" {
 		resp.Diagnostics.AddError(
-			"No P0_API_TOKEN environment variable",
+			"No P0 API token configured",
 			fmt.Sprintf(
-				"A P0 API token is required to use the P0 Terraform provider. To create a token, navigate to https://p0.app/o/%s/settings. Pass your token by setting it in the P0_API_TOKEN environment variable.",
+				"A P0 API token is required to use the P0 Terraform provider. To create a token, navigate to https://p0.app/o/%s/settings. Pass your token via the `api_token` provider attribute or the P0_API_TOKEN environment variable.",
 				model.Org.ValueString(),
 			),
 		)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -91,8 +91,10 @@ func (p *P0Provider) Configure(ctx context.Context, req provider.ConfigureReques
 		)
 	}
 
-	api_token := model.ApiToken.ValueString()
-	if api_token == "" {
+	var api_token string
+	if !model.ApiToken.IsNull() && !model.ApiToken.IsUnknown() {
+		api_token = model.ApiToken.ValueString()
+	} else {
 		api_token = os.Getenv("P0_API_TOKEN")
 	}
 	if api_token == "" {


### PR DESCRIPTION
## Summary
- The `p0` provider previously read the API token only from the `P0_API_TOKEN` environment variable. This forces orchestration layers (Terragrunt, GitHub Actions, etc.) to inject the token via process env rather than declaratively in HCL.
- Adds an optional, sensitive `api_token` attribute on the provider. When set, it takes precedence; when unset, the provider falls back to `P0_API_TOKEN` (existing behavior preserved). The missing-token error now mentions both options.
- Regenerated `docs/index.md` via `go generate ./...`.

## Usage
```hcl
provider "p0" {
  org       = "my-org"
  api_token = var.p0_api_token  # or omit and use P0_API_TOKEN
}
```

## Backwards compatibility
Fully backwards compatible. Existing configs that rely on P0_API_TOKEN continue to work unchanged.
The attribute is marked Sensitive: true, so the value is masked in plan/state output.