### PR TITLE
VEL-113 Add support for p0 login driven auth

### DIFF
--- a/internal/provider/cli_auth.go
+++ b/internal/provider/cli_auth.go
@@ -7,8 +7,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"net/http"
 	"net/url"
 	"os"
@@ -16,6 +18,11 @@ import (
 	"strings"
 	"time"
 )
+
+// errNoCliSession indicates the P0 CLI has not been used to log in. Callers may
+// swallow it to fall through to other auth sources; every other error from
+// cliFirebaseToken means a CLI session exists but could not be exchanged.
+var errNoCliSession = errors.New("no P0 CLI session found")
 
 // p0Identity mirrors the subset of ~/.p0/identity.json that the provider reads.
 type p0Identity struct {
@@ -106,14 +113,14 @@ func exchangeForFirebaseToken(ctx context.Context, apiKey, tenantId, providerId,
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("Firebase token exchange failed (%s): %s", resp.Status, strings.TrimSpace(string(body)))
+		return "", fmt.Errorf("could not exchange the CLI credential for a Firebase token (%s): %s", resp.Status, strings.TrimSpace(string(body)))
 	}
 
 	var result struct {
@@ -123,25 +130,30 @@ func exchangeForFirebaseToken(ctx context.Context, apiKey, tenantId, providerId,
 		return "", err
 	}
 	if result.IdToken == "" {
-		return "", fmt.Errorf("Firebase token exchange returned no ID token")
+		return "", fmt.Errorf("the Firebase token exchange returned no ID token")
 	}
 	return result.IdToken, nil
 }
 
 // cliFirebaseToken exchanges the credential persisted by the P0 CLI for a
 // Firebase ID token that the P0 API accepts as a bearer token. It returns
-// ("", nil) when the CLI has not been used (so callers can fall through to other
-// auth sources), and an error when a CLI session exists but cannot be exchanged.
+// errNoCliSession when the CLI has not been used, which callers may swallow to
+// fall through to other auth sources, and other errors when a CLI session exists
+// but cannot be exchanged.
 func cliFirebaseToken(ctx context.Context) (string, error) {
 	dir, err := p0ConfigDir()
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 
 	var identity p0Identity
 	if err := loadJsonFile(filepath.Join(dir, "identity.json"), &identity); err != nil {
-		// No readable identity file: the user has not logged in with the CLI.
-		return "", nil
+		// A missing identity file means the user has not logged in with the CLI;
+		// any other error is a genuine read failure worth surfacing.
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", errNoCliSession
+		}
+		return "", fmt.Errorf("could not read the P0 CLI identity: %w", err)
 	}
 
 	// expires_at is a Unix timestamp in (fractional) seconds.

--- a/internal/provider/cli_auth.go
+++ b/internal/provider/cli_auth.go
@@ -1,0 +1,171 @@
+// Copyright (c) HashiCorp, Inc. and P0 Security, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// p0Identity mirrors the subset of ~/.p0/identity.json that the provider reads.
+type p0Identity struct {
+	Credential struct {
+		AccessToken string  `json:"access_token"`
+		IdToken     string  `json:"id_token"`
+		ExpiresAt   float64 `json:"expires_at"`
+	} `json:"credential"`
+	Org struct {
+		TenantId    string `json:"tenantId"`
+		SsoProvider string `json:"ssoProvider"`
+	} `json:"org"`
+}
+
+// p0CliConfig mirrors the subset of ~/.p0/config.json that the provider reads.
+type p0CliConfig struct {
+	Fs struct {
+		ApiKey string `json:"apiKey"`
+	} `json:"fs"`
+}
+
+// p0ConfigDir returns the directory the P0 CLI persists its state to: ~/.p0,
+// suffixed with -$P0_ENV when that variable is set.
+func p0ConfigDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	dir := ".p0"
+	if env, ok := os.LookupEnv("P0_ENV"); ok {
+		dir = dir + "-" + env
+	}
+	return filepath.Join(home, dir), nil
+}
+
+// loadJsonFile reads and unmarshals the JSON file at path into v.
+func loadJsonFile(path string, v any) error {
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(contents, v)
+}
+
+// firebaseProviderId maps a P0 org's SSO provider to the Firebase Auth provider
+// ID used to exchange the CLI credential, mirroring the CLI's findProviderId.
+func firebaseProviderId(ssoProvider string) (string, error) {
+	switch ssoProvider {
+	case "google":
+		return "google.com", nil
+	case "google-oidc":
+		return "oidc.google-oidc", nil
+	case "":
+		return "", fmt.Errorf("password-based P0 logins are not supported by the Terraform provider; set the `api_token` attribute or P0_API_TOKEN instead")
+	default:
+		return "", fmt.Errorf("P0 SSO provider %q is not supported for CLI authentication; set the `api_token` attribute or P0_API_TOKEN instead", ssoProvider)
+	}
+}
+
+// exchangeForFirebaseToken trades the OIDC credential issued to the P0 CLI for a
+// Firebase ID token scoped to the org's tenant, mirroring the CLI's
+// signInWithCredential call against Identity Toolkit.
+func exchangeForFirebaseToken(ctx context.Context, apiKey, tenantId, providerId, idToken, accessToken string) (string, error) {
+	postBody := url.Values{}
+	postBody.Set("id_token", idToken)
+	postBody.Set("access_token", accessToken)
+	postBody.Set("providerId", providerId)
+
+	reqBody, err := json.Marshal(map[string]any{
+		"postBody":            postBody.Encode(),
+		"requestUri":          "http://localhost",
+		"returnIdpCredential": true,
+		"returnSecureToken":   true,
+		"tenantId":            tenantId,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	endpoint := fmt.Sprintf("https://identitytoolkit.googleapis.com/v1/accounts:signInWithIdp?key=%s", url.QueryEscape(apiKey))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(reqBody))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("Firebase token exchange failed (%s): %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+
+	var result struct {
+		IdToken string `json:"idToken"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", err
+	}
+	if result.IdToken == "" {
+		return "", fmt.Errorf("Firebase token exchange returned no ID token")
+	}
+	return result.IdToken, nil
+}
+
+// cliFirebaseToken exchanges the credential persisted by the P0 CLI for a
+// Firebase ID token that the P0 API accepts as a bearer token. It returns
+// ("", nil) when the CLI has not been used (so callers can fall through to other
+// auth sources), and an error when a CLI session exists but cannot be exchanged.
+func cliFirebaseToken(ctx context.Context) (string, error) {
+	dir, err := p0ConfigDir()
+	if err != nil {
+		return "", nil
+	}
+
+	var identity p0Identity
+	if err := loadJsonFile(filepath.Join(dir, "identity.json"), &identity); err != nil {
+		// No readable identity file: the user has not logged in with the CLI.
+		return "", nil
+	}
+
+	// expires_at is a Unix timestamp in (fractional) seconds.
+	expiresAt := time.Unix(0, int64(identity.Credential.ExpiresAt*float64(time.Second)))
+	if !time.Now().Before(expiresAt) {
+		return "", fmt.Errorf("the P0 CLI session has expired; run `p0 login` to refresh it")
+	}
+
+	var config p0CliConfig
+	if err := loadJsonFile(filepath.Join(dir, "config.json"), &config); err != nil {
+		return "", fmt.Errorf("could not read the P0 CLI config: %w", err)
+	}
+	if config.Fs.ApiKey == "" {
+		return "", fmt.Errorf("the P0 CLI config is missing a Firebase API key")
+	}
+
+	providerId, err := firebaseProviderId(identity.Org.SsoProvider)
+	if err != nil {
+		return "", err
+	}
+
+	return exchangeForFirebaseToken(ctx, config.Fs.ApiKey,
+		identity.Org.TenantId,
+		providerId,
+		identity.Credential.IdToken,
+		identity.Credential.AccessToken)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -93,10 +94,11 @@ func resolveApiToken(ctx context.Context, model P0ProviderModel, diags *diag.Dia
 		token = envToken
 	} else {
 		cliToken, err := cliFirebaseToken(ctx)
-		if err != nil {
+		if err != nil && !errors.Is(err, errNoCliSession) {
 			diags.AddError("Could not authenticate using the P0 CLI session", err.Error())
 			return ""
 		}
+		// A missing CLI session falls through to the "no auth configured" error below.
 		token = cliToken
 	}
 	if token == "" {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -5,9 +5,11 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -81,19 +83,47 @@ precedence when both are set.`,
 	}
 }
 
-func resolveApiToken(apiToken types.String, org string, diags *diag.Diagnostics) string {
+// accessTokenFromIdentityFile returns the access token written by the P0 CLI to
+// ~/.p0/identity.json, or an empty string if the file is absent, unreadable, or
+// cannot be parsed.
+func accessTokenFromIdentityFile() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+
+	contents, err := os.ReadFile(filepath.Join(home, ".p0", "identity.json"))
+	if err != nil {
+		return ""
+	}
+
+	var identity struct {
+		Credential struct {
+			AccessToken string `json:"access_token"`
+		} `json:"credential"`
+	}
+	if err := json.Unmarshal(contents, &identity); err != nil {
+		return ""
+	}
+
+	return identity.Credential.AccessToken
+}
+
+func resolveApiToken(model P0ProviderModel, diags *diag.Diagnostics) string {
 	var token string
-	if !apiToken.IsNull() && !apiToken.IsUnknown() {
-		token = apiToken.ValueString()
+	if !model.ApiToken.IsNull() && !model.ApiToken.IsUnknown() {
+		token = model.ApiToken.ValueString()
+	} else if envToken, ok := os.LookupEnv("P0_API_TOKEN"); ok {
+		token = envToken
 	} else {
-		token = os.Getenv("P0_API_TOKEN")
+		token = accessTokenFromIdentityFile()
 	}
 	if token == "" {
 		diags.AddError(
-			"No P0 API token configured",
+			"No P0 authentication configured",
 			fmt.Sprintf(
-				"A P0 API token is required to use the P0 Terraform provider. To create a token, navigate to https://p0.app/o/%s/settings. Pass your token via the `api_token` provider attribute or the P0_API_TOKEN environment variable.",
-				org,
+				"Authentication is required to use the P0 Terraform provider. Either login via the P0 CLI or provide an API token via the `api_token` provider attribute or the P0_API_TOKEN environment variable. To create a token, navigate to https://p0.app/o/%s/settings.",
+				model.Org.ValueString(),
 			),
 		)
 	}
@@ -112,7 +142,7 @@ func (p *P0Provider) Configure(ctx context.Context, req provider.ConfigureReques
 		)
 	}
 
-	api_token := resolveApiToken(model.ApiToken, model.Org.ValueString(), &resp.Diagnostics)
+	api_token := resolveApiToken(model, &resp.Diagnostics)
 
 	p0_host := model.Host.ValueString()
 	if p0_host == "" {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -5,11 +5,9 @@ package provider
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
-	"path/filepath"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -83,49 +81,23 @@ precedence when both are set.`,
 	}
 }
 
-// accessTokenFromIdentityFile returns the access token written by the P0 CLI to
-// ~/.p0/identity.json, or an empty string if the file is absent, unreadable, or
-// cannot be parsed.
-func accessTokenFromIdentityFile() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return ""
-	}
-
-	dir := ".p0"
-	if env, ok := os.LookupEnv("P0_ENV"); ok {
-		dir = dir + "-" + env
-	}
-
-	contents, err := os.ReadFile(filepath.Join(home, dir, "identity.json"))
-	if err != nil {
-		return ""
-	}
-
-	var identity struct {
-		Credential struct {
-			AccessToken string `json:"access_token"`
-		} `json:"credential"`
-	}
-	if err := json.Unmarshal(contents, &identity); err != nil {
-		return ""
-	}
-
-	return identity.Credential.AccessToken
-}
-
 // resolveApiToken returns the P0 API token to authenticate with, consulting the
 // following sources in order of precedence: the api_token provider attribute,
-// the P0_API_TOKEN environment variable, and the access token written by the P0
-// CLI to the identity file.
-func resolveApiToken(model P0ProviderModel, diags *diag.Diagnostics) string {
+// the P0_API_TOKEN environment variable, and the P0 CLI session (whose OIDC
+// credential is exchanged for a Firebase ID token).
+func resolveApiToken(ctx context.Context, model P0ProviderModel, diags *diag.Diagnostics) string {
 	var token string
 	if !model.ApiToken.IsNull() && !model.ApiToken.IsUnknown() {
 		token = model.ApiToken.ValueString()
 	} else if envToken, ok := os.LookupEnv("P0_API_TOKEN"); ok {
 		token = envToken
 	} else {
-		token = accessTokenFromIdentityFile()
+		cliToken, err := cliFirebaseToken(ctx)
+		if err != nil {
+			diags.AddError("Could not authenticate using the P0 CLI session", err.Error())
+			return ""
+		}
+		token = cliToken
 	}
 	if token == "" {
 		diags.AddError(
@@ -151,7 +123,7 @@ func (p *P0Provider) Configure(ctx context.Context, req provider.ConfigureReques
 		)
 	}
 
-	api_token := resolveApiToken(model, &resp.Diagnostics)
+	api_token := resolveApiToken(ctx, model, &resp.Diagnostics)
 
 	p0_host := model.Host.ValueString()
 	if p0_host == "" {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -92,7 +92,12 @@ func accessTokenFromIdentityFile() string {
 		return ""
 	}
 
-	contents, err := os.ReadFile(filepath.Join(home, ".p0", "identity.json"))
+	dir := ".p0"
+	if env, ok := os.LookupEnv("P0_ENV"); ok {
+		dir = dir + "-" + env
+	}
+
+	contents, err := os.ReadFile(filepath.Join(home, dir, "identity.json"))
 	if err != nil {
 		return ""
 	}
@@ -109,6 +114,10 @@ func accessTokenFromIdentityFile() string {
 	return identity.Credential.AccessToken
 }
 
+// resolveApiToken returns the P0 API token to authenticate with, consulting the
+// following sources in order of precedence: the api_token provider attribute,
+// the P0_API_TOKEN environment variable, and the access token written by the P0
+// CLI to the identity file.
 func resolveApiToken(model P0ProviderModel, diags *diag.Diagnostics) string {
 	var token string
 	if !model.ApiToken.IsNull() && !model.ApiToken.IsUnknown() {


### PR DESCRIPTION
Extends resolveApiToken (which returns the P0 API token to authenticate with) consulting the following sources in order of precedence:

* the api_token provider attribute
* the P0_API_TOKEN environment variable, and the access token written by the P0
* CLI to the identity file.