### PR TITLE
Update routes for access policy management

### DIFF
--- a/internal/provider/resources/routing_rules/routing_rule.go
+++ b/internal/provider/resources/routing_rules/routing_rule.go
@@ -47,7 +47,7 @@ func NewRoutingRule() resource.Resource {
 
 func getPath(name string) string {
 	encodedName := url.PathEscape(name)
-	return fmt.Sprintf("routing/name/%s", encodedName)
+	return fmt.Sprintf("policy/name/%s", encodedName)
 }
 
 func toJson(model RoutingRuleModelV2) RoutingRuleJson {

--- a/internal/provider/resources/routing_rules/routing_rules.go
+++ b/internal/provider/resources/routing_rules/routing_rules.go
@@ -199,7 +199,7 @@ func (rules *RoutingRules) Create(ctx context.Context, req resource.CreateReques
 
 	// Even if we are replacing the rules, it is technically an update, so retrieve the current routing rules
 	var current WorkflowLatestApi
-	_, httpErr := rules.data.Get("routing/latest", &current)
+	_, httpErr := rules.data.Get("policy/latest", &current)
 	if httpErr != nil {
 		resp.Diagnostics.AddError("Error communicating with P0", fmt.Sprintf("Unable to read routing rules, got error:\n%s", httpErr))
 		return
@@ -239,7 +239,7 @@ func (rules *RoutingRules) Read(ctx context.Context, req resource.ReadRequest, r
 	}
 
 	var latest WorkflowLatestApi
-	_, httpErr := rules.data.Get("routing/latest", &latest)
+	_, httpErr := rules.data.Get("policy/latest", &latest)
 	if httpErr != nil {
 		diag.AddError("Error communicating with P0", fmt.Sprintf("Unable to read routing rules, got error:\n%s", httpErr))
 		return


### PR DESCRIPTION
This is currently using a deprecated route on the P0 backend and should be updated.