### PR TITLE
feat(entra-id): add p0_entra_id_iam_write Terraform resource

### DIFF
--- a/examples/resources/p0_entra_id_iam_write/resource.tf
+++ b/examples/resources/p0_entra_id_iam_write/resource.tf
@@ -1,0 +1,136 @@
+locals {
+  # The Entra ID (Azure AD) tenant ID
+  tenant_id = "12345678-1234-1234-1234-123456789012"
+}
+
+provider "azuread" {
+  tenant_id = local.tenant_id
+}
+
+provider "azurerm" {
+  features {}
+}
+
+# ── Step 1: P0 Azure root integration ─────────────────────────────────────────
+# Required before the iam-write component can be installed.
+resource "p0_azure" "example" {
+  directory_id = local.tenant_id
+}
+
+# ── Step 2: App Registration ───────────────────────────────────────────────────
+resource "azuread_application_registration" "p0" {
+  display_name = "p0-security-entra-integration"
+}
+
+# Expose an API with the user_impersonation scope so the Function App can
+# accept tokens issued for this application.
+resource "azuread_application" "p0_api" {
+  display_name = azuread_application_registration.p0.display_name
+  client_id    = azuread_application_registration.p0.client_id
+
+  api {
+    requested_access_token_version = 2
+
+    oauth2_permission_scope {
+      admin_consent_description  = "Allow the application to access the API on behalf of the signed-in user."
+      admin_consent_display_name = "User Impersonation"
+      id                         = "00000000-0000-0000-0000-000000000001"
+      enabled                    = true
+      type                       = "User"
+      value                      = "user_impersonation"
+    }
+  }
+}
+
+# Federated credential — lets P0's Google service account obtain Azure tokens
+# without a client secret.
+resource "azuread_application_federated_identity_credential" "p0" {
+  depends_on     = [p0_azure.example, azuread_application_registration.p0]
+  application_id = azuread_application_registration.p0.id
+  display_name   = "P0Integration"
+  description    = "P0 service account credential"
+  issuer         = p0_azure.example.credential_info.issuer
+  subject        = p0_azure.example.service_account_id
+  audiences      = p0_azure.example.credential_info.audiences
+}
+
+resource "azuread_service_principal" "p0" {
+  client_id = azuread_application_registration.p0.client_id
+}
+
+# ── Step 3: Function App (P0 Security Perimeter) ───────────────────────────────
+resource "azurerm_resource_group" "p0" {
+  name     = "p0-security-perimeter-rg"
+  location = "West US 2"
+}
+
+resource "azurerm_storage_account" "p0" {
+  name                     = "p0securityperimeter"
+  resource_group_name      = azurerm_resource_group.p0.name
+  location                 = azurerm_resource_group.p0.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_service_plan" "p0" {
+  name                = "p0-security-perimeter-plan"
+  location            = azurerm_resource_group.p0.location
+  resource_group_name = azurerm_resource_group.p0.name
+  os_type             = "Linux"
+  sku_name            = "EP1"
+}
+
+resource "azurerm_linux_function_app" "p0" {
+  name                       = "p0-security-perimeter-${replace(local.tenant_id, "-", "")}"
+  location                   = azurerm_resource_group.p0.location
+  resource_group_name        = azurerm_resource_group.p0.name
+  service_plan_id            = azurerm_service_plan.p0.id
+  storage_account_name       = azurerm_storage_account.p0.name
+  storage_account_access_key = azurerm_storage_account.p0.primary_access_key
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  site_config {
+    application_stack {
+      docker {
+        registry_url = "https://docker.io"
+        image_name   = "p0security/p0-security-perimeter-entra"
+        image_tag    = "latest"
+      }
+    }
+  }
+
+  app_settings = {
+    MANAGED_IDENTITY_ID = azurerm_linux_function_app.p0.identity[0].principal_id
+    CALLER_APP_ID       = azuread_application_registration.p0.client_id
+  }
+
+  auth_settings_v2 {
+    auth_enabled           = true
+    unauthenticated_action = "Return401"
+
+    active_directory_v2 {
+      client_id            = azuread_application_registration.p0.client_id
+      tenant_auth_endpoint = "https://login.microsoftonline.com/${local.tenant_id}/v2.0"
+      allowed_audiences    = [azuread_application_registration.p0.client_id]
+    }
+
+    login {}
+  }
+}
+
+# ── Step 4: P0 Entra ID IAM Write ─────────────────────────────────────────────
+resource "p0_entra_id_iam_write" "example" {
+  depends_on = [
+    p0_azure.example,
+    azuread_application_federated_identity_credential.p0,
+    azurerm_linux_function_app.p0,
+  ]
+
+  tenant_id          = local.tenant_id
+  client_id          = azuread_application_registration.p0.client_id
+  sovereign_cloud_id = "AzureCloud"
+  email_field        = "userPrincipalName"
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -163,6 +163,7 @@ func (p *P0Provider) Resources(ctx context.Context) []func() resource.Resource {
 		installazure.NewAzureBastionHostStaged,
 		installazure.NewAzureIamWrite,
 		installazure.NewAzureIamWriteStaged,
+		installazure.NewEntraIdIamWrite,
 		installgcp.NewGcp,
 		installgcp.NewGcpAccessLogs,
 		installgcp.NewGcpIamAssessment,

--- a/internal/provider/resources/install/azure/common.go
+++ b/internal/provider/resources/install/azure/common.go
@@ -10,6 +10,7 @@ import (
 const (
 	AzureKey    = "azure"
 	AzureAppKey = "azure-app"
+	EntraIdKey  = "azure-ad"
 )
 
 var subscriptionIdAttribute = schema.StringAttribute{

--- a/internal/provider/resources/install/azure/entra_id_iam_write.go
+++ b/internal/provider/resources/install/azure/entra_id_iam_write.go
@@ -1,0 +1,194 @@
+package installazure
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/p0-security/terraform-provider-p0/internal"
+	"github.com/p0-security/terraform-provider-p0/internal/common"
+	installresources "github.com/p0-security/terraform-provider-p0/internal/provider/resources/install"
+)
+
+var _ resource.Resource = &entraIdIamWrite{}
+var _ resource.ResourceWithImportState = &entraIdIamWrite{}
+var _ resource.ResourceWithConfigure = &entraIdIamWrite{}
+
+func NewEntraIdIamWrite() resource.Resource {
+	return &entraIdIamWrite{}
+}
+
+type entraIdIamWriteModel struct {
+	TenantId         types.String `tfsdk:"tenant_id"`
+	ClientId         types.String `tfsdk:"client_id"`
+	SovereignCloudId types.String `tfsdk:"sovereign_cloud_id"`
+	EmailField       types.String `tfsdk:"email_field"`
+	Label            types.String `tfsdk:"label"`
+	State            types.String `tfsdk:"state"`
+}
+
+type entraIdIamWriteJson struct {
+	ClientId         string `json:"clientId"`
+	SovereignCloudId string `json:"sovereignCloudId"`
+	EmailField       string `json:"emailField"`
+	Label            string `json:"label"`
+	State            string `json:"state"`
+}
+
+type entraIdIamWriteApi struct {
+	Item entraIdIamWriteJson `json:"item"`
+}
+
+type entraIdIamWrite struct {
+	installer *common.Install
+}
+
+func (r *entraIdIamWrite) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_entra_id_iam_write"
+}
+
+func (r *entraIdIamWrite) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: `An installation of P0 for IAM management of a Microsoft Entra ID (Azure AD) tenant.
+
+To use this resource, you must also:
+- create an App Registration in your Entra tenant for P0,
+- expose an API with a ` + "`user_impersonation`" + ` scope on the App Registration,
+- add Microsoft Graph application permissions and grant admin consent,
+- create a federated identity credential on the App Registration pointing to P0's service account,
+- deploy the P0 Security Perimeter as an Azure Function App in your tenant,
+- configure App Service Authentication on the Function App using the App Registration,
+- install the ` + "`p0_azure`" + ` resource.
+
+See the example usage for the recommended pattern to define this infrastructure.`,
+		Attributes: map[string]schema.Attribute{
+			"tenant_id": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "The Microsoft Entra ID tenant (directory) ID.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(common.UuidRegex, "Entra ID tenant ID must be a valid UUID"),
+				},
+			},
+			"client_id": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "The Application (client) ID of the App Registration created for P0 in this tenant.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(common.UuidRegex, "Client ID must be a valid UUID"),
+				},
+			},
+			"sovereign_cloud_id": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "The Azure sovereign cloud environment. Use `AzureCloud` for the global cloud or `AzureUSGovernment` for the US Government cloud.",
+				Validators: []validator.String{
+					stringvalidator.OneOf("AzureCloud", "AzureUSGovernment"),
+				},
+			},
+			"email_field": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "The Entra user property used as each user's email address. One of `userPrincipalName`, `mail`, or `otherMails`.",
+				Validators: []validator.String{
+					stringvalidator.OneOf("userPrincipalName", "mail", "otherMails"),
+				},
+			},
+			"label": labelAttribute,
+			"state": common.StateAttribute,
+		},
+	}
+}
+
+func (r *entraIdIamWrite) getId(data any) *string {
+	model, ok := data.(*entraIdIamWriteModel)
+	if !ok {
+		return nil
+	}
+	return model.TenantId.ValueStringPointer()
+}
+
+func (r *entraIdIamWrite) getItemJson(json any) any {
+	inner, ok := json.(*entraIdIamWriteApi)
+	if !ok {
+		return nil
+	}
+	return &inner.Item
+}
+
+func (r *entraIdIamWrite) fromJson(ctx context.Context, diags *diag.Diagnostics, id string, json any) any {
+	data := entraIdIamWriteModel{}
+	jsonv, ok := json.(*entraIdIamWriteJson)
+	if !ok {
+		return nil
+	}
+
+	data.TenantId = types.StringValue(id)
+	data.ClientId = types.StringValue(jsonv.ClientId)
+	data.SovereignCloudId = types.StringValue(jsonv.SovereignCloudId)
+	data.EmailField = types.StringValue(jsonv.EmailField)
+	data.Label = types.StringValue(jsonv.Label)
+	data.State = types.StringValue(jsonv.State)
+
+	return &data
+}
+
+func (r *entraIdIamWrite) toJson(data any) any {
+	model, ok := data.(*entraIdIamWriteModel)
+	if !ok {
+		return nil
+	}
+	return entraIdIamWriteJson{
+		ClientId:         model.ClientId.ValueString(),
+		SovereignCloudId: model.SovereignCloudId.ValueString(),
+		EmailField:       model.EmailField.ValueString(),
+	}
+}
+
+func (r *entraIdIamWrite) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	providerData := internal.Configure(&req, resp)
+	r.installer = &common.Install{
+		Integration:  EntraIdKey,
+		Component:    installresources.IamWrite,
+		ProviderData: providerData,
+		GetId:        r.getId,
+		GetItemJson:  r.getItemJson,
+		FromJson:     r.fromJson,
+		ToJson:       r.toJson,
+	}
+}
+
+func (s *entraIdIamWrite) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var json entraIdIamWriteApi
+	var data entraIdIamWriteModel
+	s.installer.Stage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &json, &data, &struct{}{})
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	s.installer.UpsertFromStage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &json, &data)
+}
+
+func (s *entraIdIamWrite) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	s.installer.Read(ctx, &resp.Diagnostics, &resp.State, &entraIdIamWriteApi{}, &entraIdIamWriteModel{})
+}
+
+func (s *entraIdIamWrite) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	s.installer.UpsertFromStage(ctx, &resp.Diagnostics, &req.Plan, &resp.State, &entraIdIamWriteApi{}, &entraIdIamWriteModel{})
+}
+
+func (s *entraIdIamWrite) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	s.installer.Delete(ctx, &resp.Diagnostics, &req.State, &entraIdIamWriteModel{})
+}
+
+func (s *entraIdIamWrite) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("tenant_id"), req, resp)
+}


### PR DESCRIPTION
## Summary

- Adds `EntraIdKey = "azure-ad"` constant to `internal/provider/resources/install/azure/common.go`
- Implements new `p0_entra_id_iam_write` resource in `internal/provider/resources/install/azure/entra_id_iam_write.go` for registering P0's Entra ID IAM write integration
- Registers the resource in the provider
- Adds a full end-to-end example in `examples/resources/p0_entra_id_iam_write/resource.tf`

## Design notes

The resource follows the Stage + UpsertFromStage pattern (same as `p0_azure_app`) — no separate staged resource is needed because there is no intermediate Azure infrastructure to provision between staging and configuration. The backend assembler picks a service account on Stage, then the configurer validates the Entra connection and resolves the tenant display name as `label` on Configure.

**Fields:**
- `tenant_id` — Entra tenant ID (required, UUID, forces replacement)
- `client_id` — App Registration client ID (required, UUID, forces replacement)
- `sovereign_cloud_id` — `AzureCloud` or `AzureUSGovernment` (required, allows in-place update)
- `email_field` — `userPrincipalName`, `mail`, or `otherMails` (required, allows in-place update)
- `label` — resolved tenant display name (computed)
- `state` — install progress (computed)

Delete is a hard delete (not rollback) since there is no staged resource to return to.

## Test plan

- [ ] `go build ./...` passes (verified locally)
- [ ] `go test ./...` passes (verified locally — acceptance tests require a live P0 org)
- [ ] Manual acceptance test: apply example config against a real Entra tenant and verify `label` and `state` are populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)