### PR TITLE
File Transfer no longer take region and partition as intup

### DIFF
--- a/docs/resources/file_transfer.md
+++ b/docs/resources/file_transfer.md
@@ -39,15 +39,12 @@ resource "p0_file_transfer" "example" {
 
 - `account_id` (String) The AWS account ID. AWS SSH must already be installed for this account.
 - `bucket_name` (String) The name of the S3 bucket used to broker fast file transfers (without the `s3://` prefix)
-- `region` (String) The AWS region of the S3 bucket (e.g. `us-east-1`)
-
-### Optional
-
-- `aws_partition` (String) The AWS partition the bucket resides in. Usually `aws`; use `aws-us-gov` for GovCloud or `aws-cn` for China
 
 ### Read-Only
 
+- `aws_partition` (String) The AWS partition the bucket resides in. Usually `aws`; use `aws-us-gov` for GovCloud or `aws-cn` for China
 - `label` (String) The label for this installation (defaults to the AWS account ID)
+- `region` (String) The AWS region of the S3 bucket (e.g. `us-east-1`)
 - `state` (String) This item's install progress in the P0 application:
 	- 'stage': The item has been staged for installation
 	- 'configure': The item is available to be added to P0, and may be configured

--- a/internal/provider/resources/install/file_transfer/common.go
+++ b/internal/provider/resources/install/file_transfer/common.go
@@ -14,12 +14,3 @@ var Components = []string{installresources.IamWrite}
 // A DNS-style S3 bucket name: 3-63 characters, lowercase alphanumerics plus dots and
 // hyphens, beginning and ending with an alphanumeric. Mirrors the validation in the P0 app.
 var BucketNameRegex = regexp.MustCompile(`^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$`)
-
-// An AWS region identifier, e.g. us-east-1 or us-gov-east-1.
-var RegionRegex = regexp.MustCompile(`^[a-z]{2}(?:-[a-z0-9]+)+-\d+[a-z0-9]*$`)
-
-// The AWS partitions supported for file transfer.
-var Partitions = []string{"aws", "aws-us-gov", "aws-cn"}
-
-// The default AWS partition (commercial AWS).
-const DefaultPartition = "aws"

--- a/internal/provider/resources/install/file_transfer/iam_write.go
+++ b/internal/provider/resources/install/file_transfer/iam_write.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -43,8 +42,8 @@ type fileTransferIamWriteModel struct {
 
 type fileTransferIamWriteJson struct {
 	BucketName   string  `json:"bucketName"`
-	Region       string  `json:"region"`
-	AwsPartition string  `json:"awsPartition"`
+	Region       *string `json:"region,omitempty"`
+	AwsPartition *string `json:"awsPartition,omitempty"`
 	State        *string `json:"state,omitempty"`
 	Label        *string `json:"label,omitempty"`
 }
@@ -90,19 +89,11 @@ Installing File Transfer allows P0 to broker temporary, audited file transfers t
 			},
 			"region": schema.StringAttribute{
 				MarkdownDescription: `The AWS region of the S3 bucket (e.g. ` + "`us-east-1`" + `)`,
-				Required:            true,
-				Validators: []validator.String{
-					stringvalidator.RegexMatches(RegionRegex, "AWS region should be in the format: us-east-1 or us-gov-east-1"),
-				},
+				Computed:            true,
 			},
 			"aws_partition": schema.StringAttribute{
 				MarkdownDescription: `The AWS partition the bucket resides in. Usually ` + "`aws`" + `; use ` + "`aws-us-gov`" + ` for GovCloud or ` + "`aws-cn`" + ` for China`,
-				Optional:            true,
 				Computed:            true,
-				Default:             stringdefault.StaticString(DefaultPartition),
-				Validators: []validator.String{
-					stringvalidator.OneOf(Partitions...),
-				},
 			},
 			"label": schema.StringAttribute{
 				MarkdownDescription: `The label for this installation (defaults to the AWS account ID)`,
@@ -158,8 +149,16 @@ func (r *fileTransferIamWrite) fromJson(ctx context.Context, diags *diag.Diagnos
 	accountId := strings.TrimPrefix(id, awsPrefix)
 	data.AccountId = types.StringValue(accountId)
 	data.BucketName = types.StringValue(jsonv.BucketName)
-	data.Region = types.StringValue(jsonv.Region)
-	data.AwsPartition = types.StringValue(jsonv.AwsPartition)
+
+	data.Region = types.StringNull()
+	if jsonv.Region != nil {
+		data.Region = types.StringValue(*jsonv.Region)
+	}
+
+	data.AwsPartition = types.StringNull()
+	if jsonv.AwsPartition != nil {
+		data.AwsPartition = types.StringValue(*jsonv.AwsPartition)
+	}
 
 	data.State = types.StringNull()
 	if jsonv.State != nil {
@@ -184,8 +183,6 @@ func (r *fileTransferIamWrite) toJson(data any) any {
 	}
 
 	json.BucketName = datav.BucketName.ValueString()
-	json.Region = datav.Region.ValueString()
-	json.AwsPartition = datav.AwsPartition.ValueString()
 
 	// can omit state and label here as they're filled by the backend
 	return &json


### PR DESCRIPTION
File transfer provider no longer needs region and partition as inputs b/c it actually gets generated by the backend. So removing them as inputs, they should match how state and label behave.

verified it works with local terraform apply