### PR TITLE
add updated installation support for azure jump hosts

### DIFF
--- a/docs/resources/azure_bastion_host.md
+++ b/docs/resources/azure_bastion_host.md
@@ -3,32 +3,51 @@
 page_title: "p0_azure_bastion_host Resource - p0"
 subcategory: ""
 description: |-
-  Registers an Azure Bastion host with P0 for SSH access to VMs in a subscription.
-  To use this resource, you must also:
-  install the p0_azure_bastion_host_staged resource,install the p0_azure resource,install the p0_azure_app resource,install the p0_azure_iam_write resource for the same subscription,create an Azure Bastion host (e.g. via the azure_p0_bastion module),create and assign the P0 Bastion Host Management role to the P0 app (e.g. via the azure_p0_roles module).
-  Use p0_azure_bastion_host_staged computed custom_role when defining that Azure role. See examples/resources/p0_azure_bastion_host/ for a full chain.
+  Registers how P0 connects to Azure VMs in a subscription to provision SSH access: through a managed Azure Bastion host, or through a customer-managed jump host VM. Configure exactly one of azure_bastion or jump_host.
+  In both cases, you must also:
+  install the p0_azure resource,install the p0_azure_app resource,install the p0_azure_iam_write resource for the same subscription.
+  To use azure_bastion, you must additionally:
+  install the p0_azure_bastion_host_staged resource,create an Azure Bastion host (e.g. via the azure_p0_bastion module),create and assign the P0 Bastion Host Management role to the P0 app (e.g. via the azure_p0_roles module), using the staged resource's computed custom_role.
+  To use jump_host, the VM must have a public IP address on its primary network interface; P0 resolves and stores the IP at install time. You must also provide the role definition ID of the role granted to users connecting through the jump host (a built-in role, an existing custom role, or a new one with at least the required permissions — see the P0 setup instructions). No staged resource or Bastion host is needed. To let P0 terminate established jump host sessions when access is revoked, also install the p0_azure_jump_host management component.
+  See examples/resources/p0_azure_bastion_host/ for full chains.
   Example (after creating the Bastion and role in Azure):
   
   resource "p0_azure_bastion_host" "example" {
-    subscription_id    = p0_azure_bastion_host_staged.example.subscription_id
-    bastion_id         = module.azure_p0_bastion.bastion_resource_id
-    role_definition_id = module.azure_p0_roles.bastion_role_definition_id
+    subscription_id = p0_azure_bastion_host_staged.example.subscription_id
+    azure_bastion = {
+      bastion_id         = module.azure_p0_bastion.bastion_resource_id
+      role_definition_id = module.azure_p0_roles.bastion_role_definition_id
+    }
+  }
+  
+  Or, with a customer-managed jump host VM:
+  
+  resource "p0_azure_bastion_host" "example" {
+    subscription_id = local.subscription_id
+    jump_host = {
+      virtual_machine_id = "/subscriptions/<id>/resourceGroups/<rg>/providers/Microsoft.Compute/virtualMachines/<name>"
+      role_definition_id = "/subscriptions/<id>/providers/Microsoft.Authorization/roleDefinitions/<guid>"
+    }
   }
 ---
 
 # p0_azure_bastion_host (Resource)
 
-Registers an Azure Bastion host with P0 for SSH access to VMs in a subscription.
+Registers how P0 connects to Azure VMs in a subscription to provision SSH access: through a managed Azure Bastion host, or through a customer-managed jump host VM. Configure exactly one of `azure_bastion` or `jump_host`.
 
-To use this resource, you must also:
-- install the `p0_azure_bastion_host_staged` resource,
+In both cases, you must also:
 - install the `p0_azure` resource,
 - install the `p0_azure_app` resource,
-- install the `p0_azure_iam_write` resource for the same subscription,
-- create an Azure Bastion host (e.g. via the `azure_p0_bastion` module),
-- create and assign the P0 Bastion Host Management role to the P0 app (e.g. via the `azure_p0_roles` module).
+- install the `p0_azure_iam_write` resource for the same subscription.
 
-Use `p0_azure_bastion_host_staged` computed `custom_role` when defining that Azure role. See `examples/resources/p0_azure_bastion_host/` for a full chain.
+To use `azure_bastion`, you must additionally:
+- install the `p0_azure_bastion_host_staged` resource,
+- create an Azure Bastion host (e.g. via the `azure_p0_bastion` module),
+- create and assign the P0 Bastion Host Management role to the P0 app (e.g. via the `azure_p0_roles` module), using the staged resource's computed `custom_role`.
+
+To use `jump_host`, the VM must have a public IP address on its primary network interface; P0 resolves and stores the IP at install time. You must also provide the role definition ID of the role granted to users connecting through the jump host (a built-in role, an existing custom role, or a new one with at least the required permissions — see the P0 setup instructions). No staged resource or Bastion host is needed. To let P0 terminate established jump host sessions when access is revoked, also install the `p0_azure_jump_host` management component.
+
+See `examples/resources/p0_azure_bastion_host/` for full chains.
 
 
 
@@ -36,9 +55,23 @@ Example (after creating the Bastion and role in Azure):
 
 ```terraform
 resource "p0_azure_bastion_host" "example" {
-  subscription_id    = p0_azure_bastion_host_staged.example.subscription_id
-  bastion_id         = module.azure_p0_bastion.bastion_resource_id
-  role_definition_id = module.azure_p0_roles.bastion_role_definition_id
+  subscription_id = p0_azure_bastion_host_staged.example.subscription_id
+  azure_bastion = {
+    bastion_id         = module.azure_p0_bastion.bastion_resource_id
+    role_definition_id = module.azure_p0_roles.bastion_role_definition_id
+  }
+}
+```
+
+Or, with a customer-managed jump host VM:
+
+```terraform
+resource "p0_azure_bastion_host" "example" {
+  subscription_id = local.subscription_id
+  jump_host = {
+    virtual_machine_id = "/subscriptions/<id>/resourceGroups/<rg>/providers/Microsoft.Compute/virtualMachines/<name>"
+    role_definition_id = "/subscriptions/<id>/providers/Microsoft.Authorization/roleDefinitions/<guid>"
+  }
 }
 ```
 
@@ -47,6 +80,9 @@ resource "p0_azure_bastion_host" "example" {
 ```terraform
 locals {
   subscription_id = "12345678-1234-1234-1234-123456789012"
+  # A subscription uses either an Azure Bastion host or a jump host, never both,
+  # so the jump host example below uses a second subscription.
+  jump_host_subscription_id = "87654321-1234-1234-1234-123456789012"
   # From your Bastion deployment (for example module.azure_p0_bastion.bastion_resource_id)
   bastion_id = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/example/providers/Microsoft.Network/bastionHosts/example"
   # From the Azure custom role you create from p0_azure_bastion_host_staged outputs, for example:
@@ -72,6 +108,8 @@ resource "p0_azure_iam_write" "example" {
   subscription_id = local.subscription_id
 }
 
+# Option 1: a managed Azure Bastion host. Stage first to obtain the custom role
+# spec, create the role and Bastion in Azure, then register both IDs.
 resource "p0_azure_bastion_host_staged" "example" {
   depends_on = [
     p0_azure.example,
@@ -84,9 +122,31 @@ resource "p0_azure_bastion_host_staged" "example" {
 resource "p0_azure_bastion_host" "example" {
   depends_on = [p0_azure_bastion_host_staged.example]
 
-  subscription_id    = p0_azure_bastion_host_staged.example.subscription_id
-  bastion_id         = local.bastion_id
-  role_definition_id = local.bastion_role_definition_id
+  subscription_id = p0_azure_bastion_host_staged.example.subscription_id
+  azure_bastion = {
+    bastion_id         = local.bastion_id
+    role_definition_id = local.bastion_role_definition_id
+  }
+}
+
+# Option 2: a customer-managed jump host VM. No staged resource or Bastion host
+# is needed; the VM must have a public IP on its primary network interface,
+# which P0 resolves and stores at install time. role_definition_id is the role
+# granted to users connecting through the jump host (a built-in role, an
+# existing custom role, or a new one with at least the required permissions).
+resource "p0_azure_iam_write" "jump_host_example" {
+  depends_on      = [p0_azure_app.example]
+  subscription_id = local.jump_host_subscription_id
+}
+
+resource "p0_azure_bastion_host" "jump_host_example" {
+  depends_on = [p0_azure_iam_write.jump_host_example]
+
+  subscription_id = local.jump_host_subscription_id
+  jump_host = {
+    virtual_machine_id = "/subscriptions/87654321-1234-1234-1234-123456789012/resourceGroups/example/providers/Microsoft.Compute/virtualMachines/example"
+    role_definition_id = "/subscriptions/87654321-1234-1234-1234-123456789012/providers/Microsoft.Authorization/roleDefinitions/11111111-1111-1111-1111-111111111111"
+  }
 }
 ```
 
@@ -95,14 +155,38 @@ resource "p0_azure_bastion_host" "example" {
 
 ### Required
 
-- `bastion_id` (String) The full Azure resource ID of the Bastion host (e.g. from azure_p0_bastion.bastion_resource_id).
-- `role_definition_id` (String) The Azure role definition ID for the P0 Bastion Host Management role (e.g. from azure_p0_roles.bastion_role_definition_id).
-- `subscription_id` (String) The Azure subscription ID where the bastion host is used.
+- `subscription_id` (String) The Azure subscription ID where the bastion host or jump host is used.
+
+### Optional
+
+- `azure_bastion` (Attributes) Provision SSH access through a managed Azure Bastion host. Exactly one of `azure_bastion` or `jump_host` must be configured. (see [below for nested schema](#nestedatt--azure_bastion))
+- `jump_host` (Attributes) Provision SSH access through a customer-managed jump host VM. Exactly one of `azure_bastion` or `jump_host` must be configured. (see [below for nested schema](#nestedatt--jump_host))
 
 ### Read-Only
 
-- `label` (String) The label of the subscription (computed from P0).
+- `label` (String) The label of this install: the subscription label for azure_bastion, or the VM name for jump_host (computed from P0).
 - `state` (String) This item's install progress in the P0 application:
 	- 'stage': The item has been staged for installation
 	- 'configure': The item is available to be added to P0, and may be configured
 	- 'installed': The item is fully installed
+
+<a id="nestedatt--azure_bastion"></a>
+### Nested Schema for `azure_bastion`
+
+Required:
+
+- `bastion_id` (String) The full Azure resource ID of the Bastion host (e.g. from azure_p0_bastion.bastion_resource_id).
+- `role_definition_id` (String) The Azure role definition ID for the P0 Bastion Host Management role (e.g. from azure_p0_roles.bastion_role_definition_id).
+
+
+<a id="nestedatt--jump_host"></a>
+### Nested Schema for `jump_host`
+
+Required:
+
+- `role_definition_id` (String) The Azure role definition ID of the role granted to users connecting through this jump host, so they can reach a target virtual machine. Use a built-in role, an existing custom role, or create a new one with at least the required permissions.
+- `virtual_machine_id` (String) The Azure resource ID of the jump host VM, e.g. /subscriptions/<id>/resourceGroups/<rg>/providers/Microsoft.Compute/virtualMachines/<name>.
+
+Read-Only:
+
+- `ip` (String) The jump host's public IP address, resolved from the VM's primary network interface by P0 at install time (computed from P0).

--- a/docs/resources/azure_bastion_host_staged.md
+++ b/docs/resources/azure_bastion_host_staged.md
@@ -4,9 +4,10 @@ page_title: "p0_azure_bastion_host_staged Resource - p0"
 subcategory: ""
 description: |-
   Staged installation of the P0 Azure Bastion Host component. Returns the Bastion Host Management role spec so you can create the Azure role and assignment, then complete with p0_azure_bastion_host.
+  This resource is only needed for the azure_bastion option of p0_azure_bastion_host; jump host installs (the jump_host option) need no custom role and skip this resource.
   To use this resource, you must also:
   install the p0_azure resource,install the p0_azure_app resource,install the p0_azure_iam_write resource for the same subscription.
-  Read custom_role (name, description, actions, assignable_scope) when defining an azurerm_role_definition or equivalent, assign it to the P0 service principal, deploy Bastion, then pass the Bastion ARM ID and role definition ID to p0_azure_bastion_host.
+  Read custom_role (name, description, actions, assignable_scope) when defining an azurerm_role_definition or equivalent, assign it to the P0 service principal, deploy Bastion, then pass the Bastion ARM ID and role definition ID in the azure_bastion attribute of p0_azure_bastion_host.
   Example:
   
   resource "p0_azure_bastion_host_staged" "example" {
@@ -24,12 +25,14 @@ description: |-
 
 Staged installation of the P0 Azure Bastion Host component. Returns the Bastion Host Management role spec so you can create the Azure role and assignment, then complete with `p0_azure_bastion_host`.
 
+This resource is only needed for the `azure_bastion` option of `p0_azure_bastion_host`; jump host installs (the `jump_host` option) need no custom role and skip this resource.
+
 To use this resource, you must also:
 - install the `p0_azure` resource,
 - install the `p0_azure_app` resource,
 - install the `p0_azure_iam_write` resource for the same subscription.
 
-Read `custom_role` (name, description, actions, assignable_scope) when defining an `azurerm_role_definition` or equivalent, assign it to the P0 service principal, deploy Bastion, then pass the Bastion ARM ID and role definition ID to `p0_azure_bastion_host`.
+Read `custom_role` (name, description, actions, assignable_scope) when defining an `azurerm_role_definition` or equivalent, assign it to the P0 service principal, deploy Bastion, then pass the Bastion ARM ID and role definition ID in the `azure_bastion` attribute of `p0_azure_bastion_host`.
 
 
 Example:

--- a/examples/resources/p0_azure_bastion_host/resource.tf
+++ b/examples/resources/p0_azure_bastion_host/resource.tf
@@ -1,5 +1,8 @@
 locals {
   subscription_id = "12345678-1234-1234-1234-123456789012"
+  # A subscription uses either an Azure Bastion host or a jump host, never both,
+  # so the jump host example below uses a second subscription.
+  jump_host_subscription_id = "87654321-1234-1234-1234-123456789012"
   # From your Bastion deployment (for example module.azure_p0_bastion.bastion_resource_id)
   bastion_id = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/example/providers/Microsoft.Network/bastionHosts/example"
   # From the Azure custom role you create from p0_azure_bastion_host_staged outputs, for example:
@@ -25,6 +28,8 @@ resource "p0_azure_iam_write" "example" {
   subscription_id = local.subscription_id
 }
 
+# Option 1: a managed Azure Bastion host. Stage first to obtain the custom role
+# spec, create the role and Bastion in Azure, then register both IDs.
 resource "p0_azure_bastion_host_staged" "example" {
   depends_on = [
     p0_azure.example,
@@ -37,7 +42,29 @@ resource "p0_azure_bastion_host_staged" "example" {
 resource "p0_azure_bastion_host" "example" {
   depends_on = [p0_azure_bastion_host_staged.example]
 
-  subscription_id    = p0_azure_bastion_host_staged.example.subscription_id
-  bastion_id         = local.bastion_id
-  role_definition_id = local.bastion_role_definition_id
+  subscription_id = p0_azure_bastion_host_staged.example.subscription_id
+  azure_bastion = {
+    bastion_id         = local.bastion_id
+    role_definition_id = local.bastion_role_definition_id
+  }
+}
+
+# Option 2: a customer-managed jump host VM. No staged resource or Bastion host
+# is needed; the VM must have a public IP on its primary network interface,
+# which P0 resolves and stores at install time. role_definition_id is the role
+# granted to users connecting through the jump host (a built-in role, an
+# existing custom role, or a new one with at least the required permissions).
+resource "p0_azure_iam_write" "jump_host_example" {
+  depends_on      = [p0_azure_app.example]
+  subscription_id = local.jump_host_subscription_id
+}
+
+resource "p0_azure_bastion_host" "jump_host_example" {
+  depends_on = [p0_azure_iam_write.jump_host_example]
+
+  subscription_id = local.jump_host_subscription_id
+  jump_host = {
+    virtual_machine_id = "/subscriptions/87654321-1234-1234-1234-123456789012/resourceGroups/example/providers/Microsoft.Compute/virtualMachines/example"
+    role_definition_id = "/subscriptions/87654321-1234-1234-1234-123456789012/providers/Microsoft.Authorization/roleDefinitions/11111111-1111-1111-1111-111111111111"
+  }
 }

--- a/internal/common/install.go
+++ b/internal/common/install.go
@@ -108,7 +108,10 @@ func (i *Install) Stage(ctx context.Context, diags *diag.Diagnostics, plan *tfsd
 
 	created := i.FromJson(ctx, diags, *id, itemJson)
 	if created == nil {
-		reportConversionError("Bad API response", "Could not read resource data from", itemJson, diags)
+		// FromJson may have already reported a specific diagnostic
+		if !diags.HasError() {
+			reportConversionError("Bad API response", "Could not read resource data from", itemJson, diags)
+		}
 		return
 	}
 
@@ -162,7 +165,10 @@ func (i *Install) UpsertFromStage(ctx context.Context, diags *diag.Diagnostics, 
 
 	updated := i.FromJson(ctx, diags, *id, itemJson)
 	if updated == nil {
-		reportConversionError("Bad API response", "Could not read resource data from", itemJson, diags)
+		// FromJson may have already reported a specific diagnostic
+		if !diags.HasError() {
+			reportConversionError("Bad API response", "Could not read resource data from", itemJson, diags)
+		}
 		return
 	}
 
@@ -206,7 +212,10 @@ func (i *Install) Read(ctx context.Context, diags *diag.Diagnostics, state *tfsd
 
 	updated := i.FromJson(ctx, diags, *id, itemJson)
 	if updated == nil {
-		reportConversionError("Bad API response", "Could not read resource data from", itemJson, diags)
+		// FromJson may have already reported a specific diagnostic
+		if !diags.HasError() {
+			reportConversionError("Bad API response", "Could not read resource data from", itemJson, diags)
+		}
 		return
 	}
 
@@ -230,7 +239,7 @@ func (i *Install) Rollback(ctx context.Context, diags *diag.Diagnostics, state *
 
 	json := i.ToJson(model)
 	if json == nil {
-		reportConversionError("Bad Terraform state", "Could not create an API request from", json, diags)
+		reportConversionError("Bad Terraform state", "Could not create an API request from", model, diags)
 		return
 	}
 

--- a/internal/provider/resources/install/azure/bastion_host.go
+++ b/internal/provider/resources/install/azure/bastion_host.go
@@ -1,28 +1,75 @@
-// Azure Bastion host registration wires an existing Microsoft Azure Bastion into P0 for
-// subscription-scoped SSH. Stage with `p0_azure_bastion_host_staged`, create the role and Bastion in
-// Azure (for example with the `azure_p0_roles` and `azure_p0_bastion` modules), then pass the Bastion
-// ARM ID and role definition ID into this resource. See `examples/resources/p0_azure_bastion_host/`.
+// The bastion-host component registers how P0 connects to Azure VMs in a subscription to
+// provision SSH access. Exactly one connection method is configured per subscription:
+//
+//   - `azure_bastion`: a managed Azure Bastion host, plus the P0 Bastion Host Management
+//     custom role. Stage with `p0_azure_bastion_host_staged`, create the role and Bastion in
+//     Azure (for example with the `azure_p0_roles` and `azure_p0_bastion` modules), then pass
+//     the Bastion ARM ID and role definition ID here.
+//   - `jump_host`: a customer-managed jump host VM, referenced by its resource ID. No custom
+//     role or staged resource is needed; P0 resolves and stores the VM's public IP at install
+//     time.
+//
+// See `examples/resources/p0_azure_bastion_host/`.
 
 package installazure
 
 import (
 	"context"
+	"fmt"
+	"regexp"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/p0-security/terraform-provider-p0/internal"
 	"github.com/p0-security/terraform-provider-p0/internal/common"
 	installresources "github.com/p0-security/terraform-provider-p0/internal/provider/resources/install"
 )
 
+// Discriminators of the API's `bastion` union (shared/src/integrations/resources/azure/components.ts).
+const (
+	azureBastionType = "azureBastion"
+	jumpHostType     = "jumpHost"
+	// The only bastion-host reference this resource creates; "subscription"
+	// (borrow another subscription's Bastion) is configurable in the P0 app only.
+	singleBastionHostType = "single"
+)
+
+// Mirror the backend's resource-ID validation (shared/src/integrations/resources/azure/asset.ts).
+// Azure resource IDs compare case-insensitively. Role definition IDs are accepted at any scope
+// from which they can be referenced: subscription-scoped, management-group-scoped, or unscoped
+// (built-in roles, and custom roles referenced from their defining scope's root).
+var roleDefinitionResourceIdRegex = regexp.MustCompile(
+	`(?i)^(?:/subscriptions/[^/]+|/providers/Microsoft\.Management/managementGroups/[^/]+)?/providers/Microsoft\.Authorization/roleDefinitions/[^/]+$`,
+)
+
+var virtualMachineResourceIdRegex = regexp.MustCompile(
+	`(?i)^/subscriptions/[^/]+/resourceGroups/[^/]+/providers/Microsoft\.Compute/virtualMachines/[^/]+$`,
+)
+
+var bastionHostResourceIdRegex = regexp.MustCompile(
+	`(?i)^/subscriptions/[^/]+/resourceGroups/[^/]+/providers/Microsoft\.Network/bastionHosts/[^/]+$`,
+)
+
+const (
+	roleDefinitionResourceIdExample = "/subscriptions/<id>/providers/Microsoft.Authorization/roleDefinitions/<guid>"
+	virtualMachineResourceIdExample = "/subscriptions/<id>/resourceGroups/<rg>/providers/Microsoft.Compute/virtualMachines/<name>"
+	bastionHostResourceIdExample    = "/subscriptions/<id>/resourceGroups/<rg>/providers/Microsoft.Network/bastionHosts/<name>"
+)
+
 var _ resource.Resource = &azureBastionHost{}
 var _ resource.ResourceWithImportState = &azureBastionHost{}
 var _ resource.ResourceWithConfigure = &azureBastionHost{}
+var _ resource.ResourceWithConfigValidators = &azureBastionHost{}
+var _ resource.ResourceWithUpgradeState = &azureBastionHost{}
 
 func NewAzureBastionHost() resource.Resource {
 	return &azureBastionHost{}
@@ -32,25 +79,49 @@ type azureBastionHost struct {
 	installer *common.Install
 }
 
-type azureBastionHostModel struct {
-	SubscriptionId   types.String `tfsdk:"subscription_id"`
-	BastionId        string       `tfsdk:"bastion_id"`
-	RoleDefinitionId types.String `tfsdk:"role_definition_id"`
-	Label            types.String `tfsdk:"label"`
-	State            types.String `tfsdk:"state"`
+type azureBastionHostAzureBastionModel struct {
+	BastionId        string `tfsdk:"bastion_id"`
+	RoleDefinitionId string `tfsdk:"role_definition_id"`
 }
 
-// Item request/response for the P0 API (camelCase for API).
-type bastionHostBastionRef struct {
+type azureBastionHostJumpHostModel struct {
+	VirtualMachineId string       `tfsdk:"virtual_machine_id"`
+	RoleDefinitionId string       `tfsdk:"role_definition_id"`
+	Ip               types.String `tfsdk:"ip"`
+}
+
+type azureBastionHostModel struct {
+	SubscriptionId types.String                       `tfsdk:"subscription_id"`
+	AzureBastion   *azureBastionHostAzureBastionModel `tfsdk:"azure_bastion"`
+	JumpHost       *azureBastionHostJumpHostModel     `tfsdk:"jump_host"`
+	Label          types.String                       `tfsdk:"label"`
+	State          types.String                       `tfsdk:"state"`
+}
+
+// Item request/response for the P0 API (camelCase for API). `bastion` is a
+// discriminated union: `azureBastion` fields and `jumpHost` fields are
+// mutually exclusive.
+type bastionHostBastionHostRefJson struct {
 	Type      string `json:"type"`
 	BastionId string `json:"bastionId,omitempty"`
 }
 
+type bastionHostBastionJson struct {
+	Type string `json:"type"`
+	// Both options: the P0 Bastion Host Management custom role for azureBastion,
+	// or the customer-owned role granted to connecting users for jumpHost.
+	RoleDefinitionId string `json:"roleDefinitionId,omitempty"`
+	// azureBastion fields
+	BastionHost *bastionHostBastionHostRefJson `json:"bastionHost,omitempty"`
+	// jumpHost fields; `ip` is resolved server-side from the VM at install time
+	VirtualMachineId string `json:"virtualMachineId,omitempty"`
+	Ip               string `json:"ip,omitempty"`
+}
+
 type bastionHostItemJson struct {
-	Bastion          bastionHostBastionRef `json:"bastion"`
-	RoleDefinitionId string                `json:"roleDefinitionId"`
-	State            string                `json:"state,omitempty"`
-	Label            string                `json:"label,omitempty"`
+	Bastion bastionHostBastionJson `json:"bastion"`
+	State   string                 `json:"state,omitempty"`
+	Label   string                 `json:"label,omitempty"`
 }
 
 type bastionHostApi struct {
@@ -63,53 +134,161 @@ func (r *azureBastionHost) Metadata(ctx context.Context, req resource.MetadataRe
 
 func (r *azureBastionHost) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: `Registers an Azure Bastion host with P0 for SSH access to VMs in a subscription.
+		// Version 1: flat `bastion_id`/`role_definition_id` moved into the `azure_bastion`
+		// nested attribute (see UpgradeState).
+		Version: 1,
+		MarkdownDescription: `Registers how P0 connects to Azure VMs in a subscription to provision SSH access: through a managed Azure Bastion host, or through a customer-managed jump host VM. Configure exactly one of ` + "`azure_bastion`" + ` or ` + "`jump_host`" + `.
 
-To use this resource, you must also:
-- install the ` + "`p0_azure_bastion_host_staged`" + ` resource,
+In both cases, you must also:
 - install the ` + "`p0_azure`" + ` resource,
 - install the ` + "`p0_azure_app`" + ` resource,
-- install the ` + "`p0_azure_iam_write`" + ` resource for the same subscription,
-- create an Azure Bastion host (e.g. via the ` + "`azure_p0_bastion`" + ` module),
-- create and assign the P0 Bastion Host Management role to the P0 app (e.g. via the ` + "`azure_p0_roles`" + ` module).
+- install the ` + "`p0_azure_iam_write`" + ` resource for the same subscription.
 
-Use ` + "`p0_azure_bastion_host_staged`" + ` computed ` + "`custom_role`" + ` when defining that Azure role. See ` + "`examples/resources/p0_azure_bastion_host/`" + ` for a full chain.
+To use ` + "`azure_bastion`" + `, you must additionally:
+- install the ` + "`p0_azure_bastion_host_staged`" + ` resource,
+- create an Azure Bastion host (e.g. via the ` + "`azure_p0_bastion`" + ` module),
+- create and assign the P0 Bastion Host Management role to the P0 app (e.g. via the ` + "`azure_p0_roles`" + ` module), using the staged resource's computed ` + "`custom_role`" + `.
+
+To use ` + "`jump_host`" + `, the VM must have a public IP address on its primary network interface; P0 resolves and stores the IP at install time. You must also provide the role definition ID of the role granted to users connecting through the jump host (a built-in role, an existing custom role, or a new one with at least the required permissions — see the P0 setup instructions). No staged resource or Bastion host is needed. To let P0 terminate established jump host sessions when access is revoked, also install the ` + "`p0_azure_jump_host`" + ` management component.
+
+See ` + "`examples/resources/p0_azure_bastion_host/`" + ` for full chains.
 
 ` + "\n\nExample (after creating the Bastion and role in Azure):\n\n```terraform\n" +
 			"resource \"p0_azure_bastion_host\" \"example\" {\n" +
-			"  subscription_id    = p0_azure_bastion_host_staged.example.subscription_id\n" +
-			"  bastion_id         = module.azure_p0_bastion.bastion_resource_id\n" +
-			"  role_definition_id = module.azure_p0_roles.bastion_role_definition_id\n" +
+			"  subscription_id = p0_azure_bastion_host_staged.example.subscription_id\n" +
+			"  azure_bastion = {\n" +
+			"    bastion_id         = module.azure_p0_bastion.bastion_resource_id\n" +
+			"    role_definition_id = module.azure_p0_roles.bastion_role_definition_id\n" +
+			"  }\n" +
+			"}\n" +
+			"```\n" +
+			"\nOr, with a customer-managed jump host VM:\n\n```terraform\n" +
+			"resource \"p0_azure_bastion_host\" \"example\" {\n" +
+			"  subscription_id = local.subscription_id\n" +
+			"  jump_host = {\n" +
+			"    virtual_machine_id = \"" + virtualMachineResourceIdExample + "\"\n" +
+			"    role_definition_id = \"" + roleDefinitionResourceIdExample + "\"\n" +
+			"  }\n" +
 			"}\n" +
 			"```\n",
 		Attributes: map[string]schema.Attribute{
 			"subscription_id": schema.StringAttribute{
-				Description: "The Azure subscription ID where the bastion host is used.",
+				Description: "The Azure subscription ID where the bastion host or jump host is used.",
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
-			"bastion_id": schema.StringAttribute{
-				Description: "The full Azure resource ID of the Bastion host (e.g. from azure_p0_bastion.bastion_resource_id).",
-				Required:    true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
+			"azure_bastion": schema.SingleNestedAttribute{
+				Optional:            true,
+				MarkdownDescription: "Provision SSH access through a managed Azure Bastion host. Exactly one of `azure_bastion` or `jump_host` must be configured.",
+				Attributes: map[string]schema.Attribute{
+					"bastion_id": schema.StringAttribute{
+						Description: "The full Azure resource ID of the Bastion host (e.g. from azure_p0_bastion.bastion_resource_id).",
+						Required:    true,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(bastionHostResourceIdRegex, "Enter a valid Bastion host resource ID, e.g. "+bastionHostResourceIdExample+"."),
+						},
+					},
+					"role_definition_id": schema.StringAttribute{
+						Description: "The Azure role definition ID for the P0 Bastion Host Management role (e.g. from azure_p0_roles.bastion_role_definition_id).",
+						Required:    true,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(roleDefinitionResourceIdRegex, "Enter a valid role definition resource ID, e.g. "+roleDefinitionResourceIdExample+"."),
+						},
+					},
+				},
+				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.RequiresReplace(),
 				},
 			},
-			"role_definition_id": schema.StringAttribute{
-				Description: "The Azure role definition ID for the P0 Bastion Host Management role (e.g. from azure_p0_roles.bastion_role_definition_id).",
-				Required:    true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
+			"jump_host": schema.SingleNestedAttribute{
+				Optional:            true,
+				MarkdownDescription: "Provision SSH access through a customer-managed jump host VM. Exactly one of `azure_bastion` or `jump_host` must be configured.",
+				Attributes: map[string]schema.Attribute{
+					"virtual_machine_id": schema.StringAttribute{
+						Description: "The Azure resource ID of the jump host VM, e.g. " + virtualMachineResourceIdExample + ".",
+						Required:    true,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(virtualMachineResourceIdRegex, "Enter a valid virtual machine resource ID, e.g. "+virtualMachineResourceIdExample+"."),
+						},
+					},
+					"role_definition_id": schema.StringAttribute{
+						Description: "The Azure role definition ID of the role granted to users connecting through this jump host, so they can reach a target virtual machine. Use a built-in role, an existing custom role, or create a new one with at least the required permissions.",
+						Required:    true,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(roleDefinitionResourceIdRegex, "Enter a valid role definition resource ID, e.g. "+roleDefinitionResourceIdExample+"."),
+						},
+					},
+					"ip": schema.StringAttribute{
+						Description: "The jump host's public IP address, resolved from the VM's primary network interface by P0 at install time (computed from P0).",
+						Computed:    true,
+					},
+				},
+				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.RequiresReplace(),
 				},
 			},
 			"label": schema.StringAttribute{
-				Description: "The label of the subscription (computed from P0).",
+				Description: "The label of this install: the subscription label for azure_bastion, or the VM name for jump_host (computed from P0).",
 				Computed:    true,
 			},
 			"state": common.StateAttribute,
 		},
+	}
+}
+
+// Schema version 0 (provider <= v0.44.0) had flat `bastion_id` and `role_definition_id`
+// attributes; only the Azure Bastion connection method existed then. They map onto the
+// `azure_bastion` nested attribute.
+type azureBastionHostModelV0 struct {
+	SubscriptionId   types.String `tfsdk:"subscription_id"`
+	BastionId        string       `tfsdk:"bastion_id"`
+	RoleDefinitionId types.String `tfsdk:"role_definition_id"`
+	Label            types.String `tfsdk:"label"`
+	State            types.String `tfsdk:"state"`
+}
+
+func (r *azureBastionHost) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"subscription_id":    schema.StringAttribute{Required: true},
+					"bastion_id":         schema.StringAttribute{Required: true},
+					"role_definition_id": schema.StringAttribute{Required: true},
+					"label":              schema.StringAttribute{Computed: true},
+					"state":              common.StateAttribute,
+				},
+			},
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				var prior azureBastionHostModelV0
+				resp.Diagnostics.Append(req.State.Get(ctx, &prior)...)
+				if resp.Diagnostics.HasError() {
+					return
+				}
+
+				upgraded := azureBastionHostModel{
+					SubscriptionId: prior.SubscriptionId,
+					AzureBastion: &azureBastionHostAzureBastionModel{
+						BastionId:        prior.BastionId,
+						RoleDefinitionId: prior.RoleDefinitionId.ValueString(),
+					},
+					Label: prior.Label,
+					State: prior.State,
+				}
+				resp.Diagnostics.Append(resp.State.Set(ctx, &upgraded)...)
+			},
+		},
+	}
+}
+
+func (r *azureBastionHost) ConfigValidators(ctx context.Context) []resource.ConfigValidator {
+	return []resource.ConfigValidator{
+		resourcevalidator.ExactlyOneOf(
+			path.MatchRoot("azure_bastion"),
+			path.MatchRoot("jump_host"),
+		),
 	}
 }
 
@@ -139,9 +318,47 @@ func (r *azureBastionHost) fromJson(ctx context.Context, diags *diag.Diagnostics
 	data.SubscriptionId = types.StringValue(id)
 	data.State = types.StringValue(jsonv.State)
 	data.Label = types.StringValue(jsonv.Label)
-	data.RoleDefinitionId = types.StringValue(jsonv.RoleDefinitionId)
-	if jsonv.Bastion.Type == "single" {
-		data.BastionId = jsonv.Bastion.BastionId
+
+	switch jsonv.Bastion.Type {
+	case azureBastionType:
+		// This resource can only manage a directly-referenced ("single") bastion
+		// host; a "subscription" reference (borrowing another subscription's
+		// bastion) is configurable in the P0 app only. Erroring beats writing
+		// partial state: with these attributes marked RequiresReplace, partial
+		// state would produce a replacement plan that clobbers the app-side
+		// configuration on apply.
+		if jsonv.Bastion.BastionHost == nil || jsonv.Bastion.BastionHost.Type != singleBastionHostType {
+			refType := "<missing>"
+			if jsonv.Bastion.BastionHost != nil {
+				refType = jsonv.Bastion.BastionHost.Type
+			}
+			diags.AddError(
+				"Unsupported bastion host reference",
+				fmt.Sprintf("The bastion-host install for subscription %s references a bastion host of type %q; this resource can only manage type %q. "+
+					"It was likely reconfigured in the P0 app — manage it there, or remove it from Terraform state with `terraform state rm`.",
+					id, refType, singleBastionHostType),
+			)
+			return nil
+		}
+		data.AzureBastion = &azureBastionHostAzureBastionModel{
+			BastionId:        jsonv.Bastion.BastionHost.BastionId,
+			RoleDefinitionId: jsonv.Bastion.RoleDefinitionId,
+		}
+	case jumpHostType:
+		data.JumpHost = &azureBastionHostJumpHostModel{
+			VirtualMachineId: jsonv.Bastion.VirtualMachineId,
+			RoleDefinitionId: jsonv.Bastion.RoleDefinitionId,
+			Ip:               types.StringValue(jsonv.Bastion.Ip),
+		}
+	default:
+		diags.AddError(
+			"Unsupported bastion configuration",
+			fmt.Sprintf("The bastion-host install for subscription %s has bastion type %q, which this resource cannot manage. "+
+				"The install may have been created or reconfigured outside Terraform, or may require a newer provider version. "+
+				"Manage it in the P0 app, or remove it from Terraform state with `terraform state rm`.",
+				id, jsonv.Bastion.Type),
+		)
+		return nil
 	}
 
 	return &data
@@ -152,16 +369,32 @@ func (r *azureBastionHost) toJson(data any) any {
 	if !ok {
 		return nil
 	}
-	if datav.RoleDefinitionId.IsUnknown() || datav.RoleDefinitionId.IsNull() {
-		return nil
+
+	if datav.AzureBastion != nil {
+		return &bastionHostItemJson{
+			Bastion: bastionHostBastionJson{
+				Type:             azureBastionType,
+				RoleDefinitionId: datav.AzureBastion.RoleDefinitionId,
+				BastionHost: &bastionHostBastionHostRefJson{
+					Type:      singleBastionHostType,
+					BastionId: datav.AzureBastion.BastionId,
+				},
+			},
+		}
 	}
-	return &bastionHostItemJson{
-		Bastion: bastionHostBastionRef{
-			Type:      "single",
-			BastionId: datav.BastionId,
-		},
-		RoleDefinitionId: datav.RoleDefinitionId.ValueString(),
+
+	if datav.JumpHost != nil {
+		// `ip` is omitted; the backend resolves it from the VM at install time.
+		return &bastionHostItemJson{
+			Bastion: bastionHostBastionJson{
+				Type:             jumpHostType,
+				VirtualMachineId: datav.JumpHost.VirtualMachineId,
+				RoleDefinitionId: datav.JumpHost.RoleDefinitionId,
+			},
+		}
 	}
+
+	return nil
 }
 
 func (r *azureBastionHost) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {

--- a/internal/provider/resources/install/azure/bastion_host_staged.go
+++ b/internal/provider/resources/install/azure/bastion_host_staged.go
@@ -49,12 +49,14 @@ func (r *azureBastionHostStaged) Schema(ctx context.Context, req resource.Schema
 	resp.Schema = schema.Schema{
 		MarkdownDescription: `Staged installation of the P0 Azure Bastion Host component. Returns the Bastion Host Management role spec so you can create the Azure role and assignment, then complete with ` + "`p0_azure_bastion_host`" + `.
 
+This resource is only needed for the ` + "`azure_bastion`" + ` option of ` + "`p0_azure_bastion_host`" + `; jump host installs (the ` + "`jump_host`" + ` option) need no custom role and skip this resource.
+
 To use this resource, you must also:
 - install the ` + "`p0_azure`" + ` resource,
 - install the ` + "`p0_azure_app`" + ` resource,
 - install the ` + "`p0_azure_iam_write`" + ` resource for the same subscription.
 
-Read ` + "`custom_role`" + ` (name, description, actions, assignable_scope) when defining an ` + "`azurerm_role_definition`" + ` or equivalent, assign it to the P0 service principal, deploy Bastion, then pass the Bastion ARM ID and role definition ID to ` + "`p0_azure_bastion_host`" + `.
+Read ` + "`custom_role`" + ` (name, description, actions, assignable_scope) when defining an ` + "`azurerm_role_definition`" + ` or equivalent, assign it to the P0 service principal, deploy Bastion, then pass the Bastion ARM ID and role definition ID in the ` + "`azure_bastion`" + ` attribute of ` + "`p0_azure_bastion_host`" + `.
 ` + "\n\nExample:\n\n```terraform\n" +
 			"resource \"p0_azure_bastion_host_staged\" \"example\" {\n" +
 			"  depends_on = [\n" +

--- a/internal/provider/resources/install/azure/doc.go
+++ b/internal/provider/resources/install/azure/doc.go
@@ -8,5 +8,6 @@
 //     using p0_azure_app_staged outputs (app_name, credential_info), then p0_azure_app.
 //   - examples/resources/p0_azure_bastion_host_staged/ and examples/resources/p0_azure_bastion_host/ —
 //     read custom_role from p0_azure_bastion_host_staged, define the Azure custom role and Bastion,
-//     then register with p0_azure_bastion_host.
+//     then register with p0_azure_bastion_host (azure_bastion option). The jump_host option registers
+//     a customer-managed jump host VM instead and needs no staged resource or custom role.
 package installazure


### PR DESCRIPTION
**Problem**

p0-security/app#6152 restructures the Azure `bastion-host` install config:
`bastion` is now a union of `azureBastion` and a new `jumpHost` option
(a customer-managed VM, no custom role or Bastion needed). The
`p0_azure_bastion_host` resource still sends the old flat shape, which the
backend will reject, and it can't install jump hosts.

**Change**

`p0_azure_bastion_host` now takes exactly one of
`azure_bastion = { bastion_id, role_definition_id }` or
`jump_host = { virtual_machine_id }`, with resource IDs validated at plan time
and `jump_host.ip` computed server-side at install. Breaking schema change
(flat form shipped in v0.44.0): bumped to schema version 1 with a state
upgrader mapping old flat state into `azure_bastion`. Docs and examples
updated.

**Validation**

`go build` / `vet` / `test` pass (no unit tests exist here; acceptance tests
not run). Manually exercised a locally-built provider: both variants plan
cleanly, invalid combos and malformed IDs fail with clear errors, and a
schema_version-0 state file plans as "No changes" after config rewrite.

Do not release before p0-security/app#6152 merges.

**Tracking**

[CUS-622](https://linear.app/p0-security/issue/CUS-622)
